### PR TITLE
Update README to fix a pip command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ for `lambeq.ccg2discocat.DepCCGParser`.
 To install lambeq with depccg, run instead:
 ```bash
 pip install cython numpy
-pip install lambeq[depccg]
+pip install "lambeq[depccg]"
 depccg_en download
 ```
 See below for further options.


### PR DESCRIPTION
This fixes the pip install command described in #1, by putting quotes on the package name.