### PR TITLE
Add Japanese support to DepCCGParser

### DIFF
--- a/lambeq/text2diagram/depccg_parser.py
+++ b/lambeq/text2diagram/depccg_parser.py
@@ -42,14 +42,18 @@ from lambeq.text2diagram.ccg_types import CCGAtomicType
 
 if TYPE_CHECKING:
     import depccg
-    from depccg.annotator import annotate_XX, english_annotator, japanese_annotator
+    from depccg.annotator import (annotate_XX, english_annotator,
+                                  japanese_annotator)
     from depccg.cat import Category
 
+
 def _import_depccg() -> None:
-    global depccg, Category, annotate_XX, english_annotator, japanese_annotator
+    global depccg, Category
+    global annotate_XX, english_annotator, japanese_annotator
     import depccg
     import depccg.allennlp.utils
-    from depccg.annotator import annotate_XX, english_annotator, japanese_annotator
+    from depccg.annotator import (annotate_XX, english_annotator,
+                                  japanese_annotator)
     from depccg.cat import Category
     import depccg.lang
     import depccg.parsing
@@ -85,7 +89,8 @@ class DepCCGParser(CCGParser):
                  lang: str = 'en',
                  model: Optional[str] = None,
                  use_model_unary_rules: bool = False,
-                 annotator: Optional[str] = None,
+                 annotator: str = 'janome',
+                 tokenize: Optional[bool] = None,
                  device: int = -1,
                  root_cats: Optional[Iterable[str]] = None,
                  verbose: str = VerbosityLevel.PROGRESS.value,
@@ -95,23 +100,50 @@ class DepCCGParser(CCGParser):
         Parameters
         ----------
         lang : { 'en', 'ja' }
-            The language to use. Use of 'ja' is experimental and has not
-            been tested.
+            The language to use: 'en' for English, 'ja' for Japanese.
         model : str, optional
             The name of the model variant to use, if any.
-            (At time of writing) `depccg` supports 'elmo', 'rebank' and
+            At time of writing, `depccg` supports 'elmo', 'rebank' and
             'elmo_rebank' for English only.
         use_model_unary_rules : bool, default: False
             Use the unary rules supplied by the model instead of the
             ones by `lambeq`.
-        annotator : str, optional
-            The annotator to use, if any. (At time of writing) `depccg`
-            supports 'candc' and 'spacy'.
+        annotator : str, default: 'janome'
+            The annotator to use, if any.
+            At time of writing `depccg` supports 'candc' and 'spacy' for
+            English, and 'janome' and 'jigg' for Japanese.
+            By default, no annotator is used for English, and 'janome'
+            is used for Japanese.
+        tokenize : bool, optional
+            Whether to tokenise the input when annotating. This option
+            should only be specified when using the 'spacy' annotator.
         device : int, optional
             The ID of the GPU to use. By default, uses the CPU.
-        root_cats : iterable of str, default: ['S[dcl]', 'S[wq]',
-                                               'S[q]', 'S[qem]', 'NP']
-            A list of categories allowed at the root of the parse.
+        root_cats : iterable of str, optional
+            A list of categories allowed at the root of the parse. By
+            default, the English categories are:
+                - S[dcl]
+                - S[wq]
+                - S[q]
+                - S[qem]
+                - NP
+            and the Japanese categories are:
+                - NP[case=nc,mod=nm,fin=f]
+                - NP[case=nc,mod=nm,fin=t]
+                - S[mod=nm,form=attr,fin=t]
+                - S[mod=nm,form=base,fin=f]
+                - S[mod=nm,form=base,fin=t]
+                - S[mod=nm,form=cont,fin=f]
+                - S[mod=nm,form=cont,fin=t]
+                - S[mod=nm,form=da,fin=f]
+                - S[mod=nm,form=da,fin=t]
+                - S[mod=nm,form=hyp,fin=t]
+                - S[mod=nm,form=imp,fin=f]
+                - S[mod=nm,form=imp,fin=t]
+                - S[mod=nm,form=r,fin=t]
+                - S[mod=nm,form=s,fin=t]
+                - S[mod=nm,form=stem,fin=f]
+                - S[mod=nm,form=stem,fin=t]
         verbose : str, default: 'progress',
             Controls the command-line output of the parser. Only
             'progress' option is available for this parser.
@@ -125,36 +157,34 @@ class DepCCGParser(CCGParser):
                              '"progress" level of verbosity. '
                              f'`{self.verbose}` was given.')
         _import_depccg()
-        if lang.lower() == 'en':
-            self.tokenize = False
+        if lang == 'en':
             if root_cats is None:
-                root_cats = [
-                    'S[dcl]', 'S[wq]', 'S[q]', 'S[qem]', 'NP']
+                root_cats = ['S[dcl]', 'S[wq]', 'S[q]', 'S[qem]', 'NP']
             self.annotator_fun = english_annotator.get(annotator, annotate_XX)
-        elif lang.lower() == 'ja':
-            if annotator is None:
-                annotator = 'janome'
-            self.tokenize = True
+            self.tokenize = tokenize if tokenize is not None else False
+        elif lang == 'ja':
             if root_cats is None:
                 root_cats = ['NP[case=nc,mod=nm,fin=f]',
-                    'NP[case=nc,mod=nm,fin=t]',
-                    'S[mod=nm,form=attr,fin=t]',
-                    'S[mod=nm,form=base,fin=f]',
-                    'S[mod=nm,form=base,fin=t]',
-                    'S[mod=nm,form=cont,fin=f]',
-                    'S[mod=nm,form=cont,fin=t]',
-                    'S[mod=nm,form=da,fin=f]',
-                    'S[mod=nm,form=da,fin=t]',
-                    'S[mod=nm,form=hyp,fin=t]',
-                    'S[mod=nm,form=imp,fin=f]',
-                    'S[mod=nm,form=imp,fin=t]',
-                    'S[mod=nm,form=r,fin=t]',
-                    'S[mod=nm,form=s,fin=t]',
-                    'S[mod=nm,form=stem,fin=f]',
-                    'S[mod=nm,form=stem,fin=t]']
-            self.annotator_fun = japanese_annotator[annotator]
+                             'NP[case=nc,mod=nm,fin=t]',
+                             'S[mod=nm,form=attr,fin=t]',
+                             'S[mod=nm,form=base,fin=f]',
+                             'S[mod=nm,form=base,fin=t]',
+                             'S[mod=nm,form=cont,fin=f]',
+                             'S[mod=nm,form=cont,fin=t]',
+                             'S[mod=nm,form=da,fin=f]',
+                             'S[mod=nm,form=da,fin=t]',
+                             'S[mod=nm,form=hyp,fin=t]',
+                             'S[mod=nm,form=imp,fin=f]',
+                             'S[mod=nm,form=imp,fin=t]',
+                             'S[mod=nm,form=r,fin=t]',
+                             'S[mod=nm,form=s,fin=t]',
+                             'S[mod=nm,form=stem,fin=f]',
+                             'S[mod=nm,form=stem,fin=t]']
+            self.annotator_fun = japanese_annotator.get(annotator, annotate_XX)
+            self.tokenize = tokenize if tokenize is not None else True
         else:
-            raise ValueError('DepCCGParser does not support ' f'`{lang}`.')
+            raise ValueError('DepCCGParser does not support language: '
+                             f'`{lang}`.')
 
         depccg.lang.set_global_language_to(lang)
         self.supertagger, config = depccg.instance_models.load_model(model,

--- a/lambeq/text2diagram/depccg_parser.py
+++ b/lambeq/text2diagram/depccg_parser.py
@@ -157,12 +157,12 @@ class DepCCGParser(CCGParser):
                              '"progress" level of verbosity. '
                              f'`{self.verbose}` was given.')
         _import_depccg()
-        if lang == 'en':
+        if lang.lower() == 'en':
             if root_cats is None:
                 root_cats = ['S[dcl]', 'S[wq]', 'S[q]', 'S[qem]', 'NP']
             self.annotator_fun = english_annotator.get(annotator, annotate_XX)
             self.tokenize = tokenize if tokenize is not None else False
-        elif lang == 'ja':
+        elif lang.lower() == 'ja':
             if root_cats is None:
                 root_cats = ['NP[case=nc,mod=nm,fin=f]',
                              'NP[case=nc,mod=nm,fin=t]',

--- a/lambeq/text2diagram/depccg_parser.py
+++ b/lambeq/text2diagram/depccg_parser.py
@@ -125,13 +125,13 @@ class DepCCGParser(CCGParser):
                              '"progress" level of verbosity. '
                              f'`{self.verbose}` was given.')
         _import_depccg()
-        if lang == 'en':
+        if lang.lower() == 'en':
             self.tokenize = False
             if root_cats is None:
                 root_cats = [
                     'S[dcl]', 'S[wq]', 'S[q]', 'S[qem]', 'NP']
             self.annotator_fun = english_annotator.get(annotator, annotate_XX)
-        elif lang == 'ja':
+        elif lang.lower() == 'ja':
             if annotator is None:
                 annotator = 'janome'
             self.tokenize = True


### PR DESCRIPTION
Updated DepCCGParser to support Japanese.
The sample code is as follows.

## 1. Prepare depccg.
```bash
pip install cython numpy depccg
depccg_en download
depccg_ja download
```

## 2. Install Japanese fonts on Ubuntu.
```bash
apt install -y fonts-migmix
rm ~/.cache/matplotlib/fontlist-v330.json
````

## 3. Set the matplotlib Japanese font in the jupyter notebook python code.
```python
import matplotlib
from matplotlib.font_manager import FontProperties

font_path = "/usr/share/fonts/truetype/migmix/migmix-1p-regular.ttf"
font_prop = FontProperties(fname=font_path)
matplotlib.rcParams["font.family"] = font_prop.get_name()
```

## 4. Use sentence2diagram in the jupyter notebook python code.
```python
from lambeq import DepCCGParser
from discopy import grammar

parser = DepCCGParser(lang='ja')
diagram = parser.sentence2diagram('これはテストの文です。')
grammar.draw(diagram, figsize=(14,3), fontsize=12)
```

## 5. Use ansatz in the jupyter notebook python code.
```python
from lambeq import AtomicType, IQPAnsatz

# Define atomic types
N = AtomicType.NOUN
S = AtomicType.SENTENCE

# Convert string diagram to quantum circuit
ansatz = IQPAnsatz({N: 1, S: 1}, n_layers=2)
discopy_circuit = ansatz(diagram)
discopy_circuit.draw(figsize=(15,10))
```

## 6. Use pytket in the jupyter notebook python code.
```python
from pytket.circuit.display import render_circuit_jupyter

tket_circuit = discopy_circuit.to_tk()
render_circuit_jupyter(tket_circuit)
```
