### PR TITLE
Update workflow

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -54,9 +54,6 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install DisCoPy 0.5 from GitHub
-      if: github.ref_name != 'release' && github.ref_name != 'beta'
-      run: pip install git+https://github.com/discopy/discopy@0.5
     - name: Install base package
       run: pip install .
     - name: Check package import works

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,7 @@ packages =
     lambeq.tokeniser
     lambeq.training
 install_requires =
-    discopy ~= 0.5.0
+    discopy ~= 0.5.1
     pytket >= 0.19.2
     pyyaml
     spacy >= 3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,7 @@ packages =
     lambeq.tokeniser
     lambeq.training
 install_requires =
-    discopy ~= 0.5.1
+    discopy ~= 0.5.1.1
     pytket >= 0.19.2
     pyyaml
     spacy >= 3.0


### PR DESCRIPTION
The `build_test.yml` workflow installs DisCoPy directly from a GitHub branch, which is not a sustainable.
This PR removes this step of the workflow and updates the requirements to `discopy~=0.5.1.1` instead.