### PR TITLE
Add CCGTree.to_json(original=True)

### DIFF
--- a/lambeq/bobcat/tree.py
+++ b/lambeq/bobcat/tree.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from dataclasses import dataclass, replace
 from enum import Enum
 from functools import cached_property
-from typing import Any
+from typing import Dict, Any
 
 from lambeq.bobcat.lexicon import Atom, Category, Feature, Relation
 
@@ -290,6 +290,16 @@ class ParseTree:
     @property
     def deps(self) -> list[Dependency]:
         return self.deps_and_tags[0]
+
+    def to_json(self) -> Dict[str, Any]:
+        data = {'type': str(self.cat), 'rule': self.rule.name}
+        if self.left:
+            data['children'] = [self.left.to_json()]
+        if self.right:
+            data['children'].append(self.right.to_json())
+        if not (self.left or self.right):
+            data['text'] = self.word
+        return data
 
 
 def Lexical(cat: Category, word: str, index: int) -> ParseTree:

--- a/lambeq/text2diagram/ccg_tree.py
+++ b/lambeq/text2diagram/ccg_tree.py
@@ -265,8 +265,10 @@ class CCGTree:
                              in new_tree.children]
         return new_tree
 
-    def to_json(self) -> _JSONDictT:
+    def to_json(self, original=False) -> _JSONDictT:
         """Convert tree into JSON form."""
+        if original:
+            return tree.metadata['original'].to_json()
         if self is None:  # Allows doing CCGTree.to_json(X) for optional X
             return None  # type: ignore[unreachable]
 

--- a/tests/test_bobcat.py
+++ b/tests/test_bobcat.py
@@ -1,7 +1,32 @@
 import pickle
 
-from lambeq.bobcat.lexicon import Atom
+from lambeq import BobcatParser
+from lambeq.bobcat.lexicon import Atom, Category
+from lambeq.bobcat.tree import ParseTree, Rule
 
 
 def test_fast_int_enum():
     assert pickle.loads(pickle.dumps(Atom('N'))) == Atom('N')
+
+
+def test_to_json():
+    parser = BobcatParser()
+    tree = parser.sentence2tree("Alice loves Bob")
+    assert tree.to_json(original=True) == {
+        'type': 'S[dcl]',
+        'rule': 'BA',
+        'children': [
+            {
+                'type': 'NP',
+                'rule': 'U',
+                'children': [{'type': 'N', 'rule': 'L', 'text': 'Alice'}]},
+            {
+                'type': 'S[dcl]\\NP',
+                'rule': 'FA',
+                'children': [
+                    {'type': '(S[dcl]\\NP)/NP', 'rule': 'L', 'text': 'loves'},
+                    {
+                        'type': 'NP',
+                        'rule': 'U',
+                        'children': [
+                            {'type': 'N', 'rule': 'L', 'text': 'Bob'}]}]}]}


### PR DESCRIPTION
This PR adds the option to export the original tree to JSON, so that the user can access e.g. the features `S[dcl]` etc.