### PR TITLE
better pedagogical readability

### DIFF
--- a/docs/tutorials/monoidal.ipynb
+++ b/docs/tutorials/monoidal.ipynb
@@ -53,7 +53,11 @@
    "source": [
     "from lambeq.backend.grammar import Box, Id, Ty\n",
     "\n",
-    "A, B, C, D = map(Ty, 'ABCD')\n",
+    "A = Ty('A')\n",
+    "B = Ty('A')\n",
+    "C = Ty('A')\n",
+    "D = Ty('A')\n",
+
     "\n",
     "f = Box('f', A, B)\n",
     "g = Box('g', B, C)\n",

--- a/docs/tutorials/monoidal.ipynb
+++ b/docs/tutorials/monoidal.ipynb
@@ -54,9 +54,9 @@
     "from lambeq.backend.grammar import Box, Id, Ty\n",
     "\n",
     "A = Ty('A')\n",
-    "B = Ty('A')\n",
-    "C = Ty('A')\n",
-    "D = Ty('A')\n",
+    "B = Ty('B')\n",
+    "C = Ty('C')\n",
+    "D = Ty('D')\n",
 
     "\n",
     "f = Box('f', A, B)\n",


### PR DESCRIPTION
Was teaching this to a physicist/linguist, who didn't know much of Python. Bringing in Map() in the tutorial is an overkill pedagogically. Already student is trying to wrap his head around the new class Ty(). the map here just added unnecessary extra information making one think, map is important to create objects (e.g.A of type Ty)