### PR TITLE
Circuit ansatze should be dagger functors

### DIFF
--- a/lambeq/ansatz/circuit.py
+++ b/lambeq/ansatz/circuit.py
@@ -38,7 +38,7 @@ import numpy as np
 from sympy import Symbol, symbols
 
 from lambeq.ansatz import BaseAnsatz
-from lambeq.backend.grammar import Box, Daggered, Diagram, Functor, Ty
+from lambeq.backend.grammar import Box, Diagram, Functor, Ty
 from lambeq.backend.quantum import (
     Bra,
     CRz,

--- a/lambeq/ansatz/circuit.py
+++ b/lambeq/ansatz/circuit.py
@@ -125,9 +125,6 @@ class CircuitAnsatz(BaseAnsatz):
         return self.ob_map[ty]
 
     def _ar(self, _: Functor, box: Box) -> Circuit:
-        if isinstance(box, Daggered):
-            return self._ar(_, box.dagger()).dagger()
-
         label = self._summarise_box(box)
         dom, cod = self.ob_size(box.dom), self.ob_size(box.cod)
 

--- a/lambeq/ansatz/circuit.py
+++ b/lambeq/ansatz/circuit.py
@@ -38,7 +38,7 @@ import numpy as np
 from sympy import Symbol, symbols
 
 from lambeq.ansatz import BaseAnsatz
-from lambeq.backend.grammar import Box, Diagram, Functor, Ty
+from lambeq.backend.grammar import Box, Diagram, Functor, Ty, Daggered
 from lambeq.backend.quantum import (
     Bra,
     CRz,
@@ -125,6 +125,9 @@ class CircuitAnsatz(BaseAnsatz):
         return self.ob_map[ty]
 
     def _ar(self, _: Functor, box: Box) -> Circuit:
+        if isinstance(box, Daggered):
+            return self._ar(_, box.dagger()).dagger()
+        
         label = self._summarise_box(box)
         dom, cod = self.ob_size(box.dom), self.ob_size(box.cod)
 

--- a/lambeq/ansatz/circuit.py
+++ b/lambeq/ansatz/circuit.py
@@ -38,7 +38,7 @@ import numpy as np
 from sympy import Symbol, symbols
 
 from lambeq.ansatz import BaseAnsatz
-from lambeq.backend.grammar import Box, Diagram, Functor, Ty, Daggered
+from lambeq.backend.grammar import Box, Daggered, Diagram, Functor, Ty
 from lambeq.backend.quantum import (
     Bra,
     CRz,
@@ -127,7 +127,7 @@ class CircuitAnsatz(BaseAnsatz):
     def _ar(self, _: Functor, box: Box) -> Circuit:
         if isinstance(box, Daggered):
             return self._ar(_, box.dagger()).dagger()
-        
+
         label = self._summarise_box(box)
         dom, cod = self.ob_size(box.dom), self.ob_size(box.cod)
 

--- a/lambeq/backend/grammar.py
+++ b/lambeq/backend/grammar.py
@@ -1571,6 +1571,9 @@ class Daggered(Box):
 
     def dagger(self) -> Box:
         return self.box
+    
+    def apply_functor(self, functor: Functor) -> Diagrammable:
+        return functor(self.dagger()).dagger()
 
     @classmethod
     def from_json(cls, data: _JSONDictT | str) -> Self:

--- a/lambeq/backend/grammar.py
+++ b/lambeq/backend/grammar.py
@@ -362,6 +362,9 @@ class Diagrammable(Protocol):
 
         """
 
+    def dagger(self) -> Diagrammable:
+        """Implements conjugation of diagrams."""
+
     def __matmul__(self, rhs: Diagrammable | Ty) -> Diagrammable:
         """Implements the tensor operator `@` with another diagram."""
 

--- a/lambeq/backend/grammar.py
+++ b/lambeq/backend/grammar.py
@@ -1571,7 +1571,7 @@ class Daggered(Box):
 
     def dagger(self) -> Box:
         return self.box
-    
+
     def apply_functor(self, functor: Functor) -> Diagrammable:
         return functor(self.dagger()).dagger()
 

--- a/tests/backend/test_grammar.py
+++ b/tests/backend/test_grammar.py
@@ -277,6 +277,7 @@ def test_Functor_on_box():
     assert func(g.r) == func(g).r == g_z.r
     assert func(f >> g) == f_z >> g_z
     assert func(f @ g) == f_z @ g_z
+    assert func(f.dagger()) == func(f).dagger()
 
     def bad_ar(func, box):
         return Box("BOX", a, c) if box.cod == b else box

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -320,3 +320,20 @@ space_ty = Ty(' ')
 def test_special_characters(box, expected_sym_count):
     ansatz = Sim15Ansatz({n_ty: 2, comma_ty: 2, space_ty: 2}, n_layers=1)
     assert(len(ansatz(box).free_symbols) == expected_sym_count)
+
+
+def test_ansatz_is_dagger_functor():
+    ansatz = IQPAnsatz({N: 1, S: 1}, n_layers=1)
+    diagram = Word('John', N)
+    circuit1 = ansatz(diagram).dagger()
+    circuit2 = ansatz(diagram.dagger())
+    assert circuit1 == circuit2
+
+def test_ansatz_is_dagger_functor_sentence():
+    ansatz = IQPAnsatz({N: 1, S: 1}, n_layers=1)
+    diagram = (Word('Alice', N) @ Word('runs', N >> S) >>
+               Cup(N, N.r) @ S)
+
+    circuit1 = ansatz(diagram).dagger().normal_form()
+    circuit2 = ansatz(diagram.dagger()).normal_form()
+    assert circuit1 == circuit2


### PR DESCRIPTION
It would be nice to have `CircuitAnsatz` acting as a __dagger functor__, that is

```python
ansatz(diagram).dagger() == ansatz(diagram.dagger())
```


Currently this is not true. For instance:
```python
from lambeq import IQPAnsatz, AtomicType
from lambeq.backend import Word
from lambeq.backend.drawing import draw_equation

ansatz = IQPAnsatz({AtomicType.NOUN: 1}, n_layers=1)
diagram = Word('John', AtomicType.NOUN)

circ1 = ansatz(diagram).dagger()
circ2 = ansatz(diagram.dagger())
draw_equation(circ1, circ2, symbol='!=', figsize=(6, 6))
```
![b13fb54a-38dd-4d41-9e0c-353f6f86a964](https://github.com/user-attachments/assets/7eb72bd0-8df4-4984-be2f-c6b4760f8109)
Note that the symbols of `circ2` are completely different to those in `circ1`. The ansatz simply takes the dagger as part of the symbol names. 
This behaviour means that the use of `RemoveCupsRewriter` would lead to circuits that are outright different to those without the use of the rewriter. This should be undesirable as the role of `RemoveCupsRewriter` should be merely to improve computational efficiency, while keeping outputs untouched. 

### The proposed fix
In the `_ar` method of the base class `CircuitAnsat`, a check is added to see if the box is daggered. If so, the un-daggered box is passed to the ansatz whose output would be then daggered. 