### PR TITLE
Add implementation for `grammar.Frame`

### DIFF
--- a/lambeq/backend/grammar.py
+++ b/lambeq/backend/grammar.py
@@ -246,7 +246,7 @@ class Ty(Entity):
             objects = reversed(self.objects) if z % 2 == 1 else self.objects
             return type(self)(
                 objects=[ob.rotate(z)
-                         for ob in objects])  # type: ignore[union-attr]
+                         for ob in objects])
 
     def unwind(self) -> Self:
         return self.rotate(-self.z)

--- a/lambeq/backend/grammar.py
+++ b/lambeq/backend/grammar.py
@@ -2113,10 +2113,6 @@ class Frame(Box):
             'components': [component.to_json(is_top_level=False)
                            for component in self.components]
         }
-        for component in self.components:
-            print(f'{component = }')
-            print(json.dumps(component.to_json(is_top_level=False)))
-            print('*' * 100)
 
         if is_top_level:
             data_dict['category'] = self.category.name

--- a/lambeq/backend/grammar.py
+++ b/lambeq/backend/grammar.py
@@ -752,9 +752,7 @@ class Diagram(Entity):
 
     @property
     def has_frames(self) -> bool:
-        return any([(isinstance(box, Frame)
-                     or isinstance(box, DaggeredFrame))
-                    for box in self.boxes])
+        return any([isinstance(box, Frame) for box in self.boxes])
 
     @classmethod
     def create_pregroup_diagram(

--- a/tests/backend/test_grammar.py
+++ b/tests/backend/test_grammar.py
@@ -311,9 +311,25 @@ def test_deepcopy():
     from copy import deepcopy
     import pickle
 
-    s = Ty('s')
+    n, s = map(Ty, 'ns')
     b1 = Box('copy', s, s, 1)
     b2 = Box('copy2', s, s, 1)
+    words1 = [Word('John', n),
+              Word('walks', n.r @ s),
+              Word('in', s.r @ n.r.r @ n.r @ s @ n.l),
+              Word('the', n @ n.l),
+              Word('park', n)]
+    cups1 = [(Cup, 2, 3), (Cup, 7, 8), (Cup, 9, 10), (Cup, 1, 4), (Cup, 0, 5)]
+    d1 = Diagram.create_pregroup_diagram(words1, cups1)
+
+    words2 = [Word('John', n),
+              Word('gave', n.r @ s @ n.l @ n.l),
+              Word('Mary', n),
+              Word('a', n @ n.l),
+              Word('flower', n)]
+    cups2 = [(Cup, 0, 1), (Swap, 3, 4), (Cup, 4, 5), (Cup, 7, 8), (Cup, 3, 6)]
+    d2 = Diagram.create_pregroup_diagram(words2, cups2)
+
     cases = (
         Ty(),
         s,
@@ -332,7 +348,9 @@ def test_deepcopy():
         Swap(s @ s, s @ s),
         Word('Alice', s),
         Word('Alice', s) @ Word('runs', s.r @ s) >> \
-            Cup(s, s.r) @ Id(s)
+            Cup(s, s.r) @ Id(s),
+        Frame('frame', dom=n, cod=n @ n, components=d1),
+        d2 @ Frame('frame', dom=n, cod=n @ n, components=d1),
     )
 
     for case in cases:
@@ -439,6 +457,7 @@ def test_diagram_has_frame():
     )
     d @= f
     assert d.has_frames
+    assert d.dagger().has_frames
 
 
 def test_frame_manipulation():

--- a/tests/backend/test_grammar.py
+++ b/tests/backend/test_grammar.py
@@ -330,6 +330,8 @@ def test_deepcopy():
     cups2 = [(Cup, 0, 1), (Swap, 3, 4), (Cup, 4, 5), (Cup, 7, 8), (Cup, 3, 6)]
     d2 = Diagram.create_pregroup_diagram(words2, cups2)
 
+    f1 = Frame('frame', dom=n, cod=n @ n, components=[d1])
+
     cases = (
         Ty(),
         s,
@@ -349,8 +351,9 @@ def test_deepcopy():
         Word('Alice', s),
         Word('Alice', s) @ Word('runs', s.r @ s) >> \
             Cup(s, s.r) @ Id(s),
-        Frame('frame', dom=n, cod=n @ n, components=d1),
-        d2 @ Frame('frame', dom=n, cod=n @ n, components=d1),
+        f1,
+        d2 @ Frame('frame', dom=n, cod=n @ n, components=[d1, f1]),
+        f1 @ Frame('frame', dom=n, cod=n @ n, components=[d1, f1]).dagger(),
     )
 
     for case in cases:
@@ -373,21 +376,23 @@ def test_to_from_json():
     b1 = Box('copy', s, s, 1)
     b2 = Box('copy2', s, s, 1)
 
-    words1 = [Word("John", n),
-              Word("walks", n.r @ s),
-              Word("in", s.r @ n.r.r @ n.r @ s @ n.l),
-              Word("the", n @ n.l),
-              Word("park", n)]
+    words1 = [Word('John', n),
+              Word('walks', n.r @ s),
+              Word('in', s.r @ n.r.r @ n.r @ s @ n.l),
+              Word('the', n @ n.l),
+              Word('park', n)]
     cups1 = [(Cup, 2, 3), (Cup, 7, 8), (Cup, 9, 10), (Cup, 1, 4), (Cup, 0, 5)]
     d1 = Diagram.create_pregroup_diagram(words1, cups1)
 
-    words2 = [Word("John", n),
-              Word("gave", n.r @ s @ n.l @ n.l),
-              Word("Mary", n),
-              Word("a", n @ n.l),
-              Word("flower", n)]
+    words2 = [Word('John', n),
+              Word('gave', n.r @ s @ n.l @ n.l),
+              Word('Mary', n),
+              Word('a', n @ n.l),
+              Word('flower', n)]
     cups2 = [(Cup, 0, 1), (Swap, 3, 4), (Cup, 4, 5), (Cup, 7, 8), (Cup, 3, 6)]
     d2 = Diagram.create_pregroup_diagram(words2, cups2)
+
+    f1 = Frame('frame', dom=n, cod=n @ n, components=[d1])
 
     cases = (
         Ty(),
@@ -410,6 +415,9 @@ def test_to_from_json():
             Cup(s, s.r) @ Id(s),
         d1,
         d2,
+        f1,
+        d2 @ Frame('frame', dom=n, cod=n @ n, components=[d1, f1]),
+        f1 @ Frame('frame', dom=n, cod=n @ n, components=[d1, f1]).dagger(),
     )
 
     for case in cases:


### PR DESCRIPTION
This PR implements the `Frame` class, which is an abstract container that can contain other diagrams as its components. It also adds the `DaggeredFrame` class, which handles the dagger operation on frames.