### PR TITLE
Implement coloring modes

### DIFF
--- a/lambeq/backend/drawing/drawing.py
+++ b/lambeq/backend/drawing/drawing.py
@@ -453,9 +453,9 @@ def _get_box_color(box: grammar.Diagrammable,
         if isinstance(box, grammar.Frame) and hasattr(box, 'name'):
             frame_attr = getattr(box, f'frame_{coloring_mode}')
             if coloring_mode == ColoringMode.TYPE:
-                frame_attr += (len(FRAME_COLORS) // 7) * box.frame_order
+                frame_attr += (len(FRAME_COLORS) // 7) * (box.frame_order - 1)
 
-            color = FRAME_COLORS[frame_attr % len(FRAME_COLORS)]
+            color = FRAME_COLORS[(frame_attr - 1) % len(FRAME_COLORS)]
 
     return color
 

--- a/lambeq/backend/drawing/drawing_backend.py
+++ b/lambeq/backend/drawing/drawing_backend.py
@@ -21,6 +21,7 @@ Abstract base class for drawing backend.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from enum import Enum
 import itertools
 
 from lambeq.backend.drawing.drawable import DrawableDiagram
@@ -48,6 +49,7 @@ COLORS: dict[str, str] = {
     'blue': '#776ff3',
     'yellow': '#f7f700',
     'black': '#000000',
+    'gray': '#e0e0e0'
 }
 for color in FRAME_COLORS:
     COLORS[color] = color
@@ -60,6 +62,26 @@ SHAPES: dict[str, str] = {
     'circle': 'o',
     'plus': '+',
 }
+
+
+class ColoringMode(str, Enum):
+    """An enumeration for the coloring modes when coloring is used.
+
+    Frames can be colored by:
+
+    .. glossary::
+
+        TYPE
+            The number of holes in the frame
+
+        ORDER
+            The level of nesting of the frame, increasing from
+            the inside going outward.
+
+    """
+
+    TYPE = 'type'
+    ORDER = 'order'
 
 
 class DrawingBackend(ABC):

--- a/lambeq/backend/grammar.py
+++ b/lambeq/backend/grammar.py
@@ -2072,6 +2072,19 @@ class Frame(Box):
     def __hash__(self) -> int:
         return hash(repr(self))
 
+    @property
+    def frame_type(self):
+        """The number of holes in the frame."""
+        return len(self.components)
+
+    @property
+    def frame_order(self):
+        """The level of nesting in the frame increasing from the inside
+        going outward."""
+        component_frame_orders = [c.frame_order if isinstance(c, Frame) else 0
+                                  for c in self.components]
+        return max(component_frame_orders) + 1
+
     @classmethod
     def from_json(cls, data: _JSONDictT | str) -> Self:
         """Decode a JSON object or string into a

--- a/tests/backend/test_grammar.py
+++ b/tests/backend/test_grammar.py
@@ -465,6 +465,16 @@ def test_frame():
     )
     assert f.name == 'f1'
     assert len(f.components) == 4
+    assert f.frame_type == 4
+    assert f.frame_order == 1
+
+    f2 = Frame('f2', n, n, components=[f, f])
+    f3 = Frame('f3', n @ n, n @ n, components=[f2])
+
+    assert f2.frame_type == 2
+    assert f2.frame_order == 2
+    assert f3.frame_type == 1
+    assert f3.frame_order == 3
 
 
 def test_diagram_has_frame():


### PR DESCRIPTION
Fixes #174.
Fixes #173.

The `draw()` method now has a `coloring_mode` flag which can take one of two values:
* `'type'` (default) - the number of holes in the frame. The starting color depends on the order of the frame
* `'order'` - the nesting level for the frame, increasing from inside to outside

See examples below.