### PR TITLE
Fix `KeyError` encountered with some texts

### DIFF
--- a/lambeq/backend/pregroup_tree.py
+++ b/lambeq/backend/pregroup_tree.py
@@ -125,8 +125,7 @@ class PregroupTreeNode:
         if not isinstance(other, PregroupTreeNode):
             return NotImplemented
         return (self.word == other.word
-                and self.ind == other.ind
-                and self.typ == other.typ)
+                and self.ind == other.ind)
 
     @cached_property
     def _tree_repr(self) -> str:
@@ -371,3 +370,20 @@ class PregroupTreeNode:
             else:
                 print('Cannot perform merge when parent and child '
                       + "types don't match or tokens are not consecutive.")
+
+    def remove_self_cycles(self) -> None:
+        """Removes the children of this node that is the same token,
+        i.e. self-cycles.
+
+        This is used before breaking cycles.
+        """
+
+        new_children = []
+        for c in self.children:
+            if self.is_same_word(c):
+                c.parent = None
+            else:
+                new_children.append(c)
+        self.children = new_children
+        for c in self.children:
+            c.remove_self_cycles()

--- a/lambeq/experimental/discocirc/reader.py
+++ b/lambeq/experimental/discocirc/reader.py
@@ -342,7 +342,9 @@ class DisCoCircReader(Reader):
             tree = self._sentence2tree(sentence, break_cycles)
 
             tree_toks = tree.get_words()
-            reidxr = self._calculate_reindices(sentence, tree_toks)
+            tree_toks_indxs = tree.get_word_indices()
+            reidxr = self._calculate_reindices(sentence, tree_toks,
+                                               tree_toks_indxs)
             reidxr[None] = None
 
             tree = rewriter(tree)
@@ -400,10 +402,11 @@ class DisCoCircReader(Reader):
 
     def _calculate_reindices(self,
                              orig_toks,
-                             parsed_toks):
+                             parsed_toks,
+                             parsed_toks_indxs):
         reindexer = {}
         j = 0
-        for i, otok in enumerate(parsed_toks):
+        for i, otok in zip(parsed_toks_indxs, parsed_toks):
             while j < len(orig_toks) and orig_toks[j] != otok:
                 j += 1
             reindexer[i] = j

--- a/lambeq/text2diagram/pregroup_tree_converter.py
+++ b/lambeq/text2diagram/pregroup_tree_converter.py
@@ -234,7 +234,12 @@ def remove_cycles(root: PregroupTreeNode) -> None:
     root_word_idx = root.ind
     nodes = root.get_nodes()
     assert len(nodes[root_word_idx]) == 1
+
     root_node = nodes[root_word_idx][0]
+
+    # Remove nodes that cycles to itself
+    # (see https://github.com/CQCL/lambeq/issues/180)
+    root_node.remove_self_cycles()
 
     for _, nodes_for_idx in enumerate(nodes):
         if len(nodes_for_idx) > 1:

--- a/tests/backend/test_pregroup_tree.py
+++ b/tests/backend/test_pregroup_tree.py
@@ -46,6 +46,12 @@ t4_n1 = PregroupTreeNode(word='1', typ=n, ind=1, children=[t4_n2])
 t4_n0 = PregroupTreeNode(word='0', typ=s, ind=0, children=[t4_n1, t4_n2_2])
 t4 = t4_n0
 
+t5_n2 = PregroupTreeNode(word='and', typ=n.r @ s @ n.r.r.r @ s.r.r, ind=2)
+t5_n1 = PregroupTreeNode(word='an', typ=n, ind=1)
+t5_n2_2 = PregroupTreeNode(word='and', typ=s, ind=2, children=[t5_n1, t5_n2])
+t5_n0 = PregroupTreeNode(word='when', typ=s, ind=0, children=[t5_n2_2])
+t5 = t5_n0
+
 
 def test_get_nodes():
     assert t1.get_nodes() == [
@@ -228,3 +234,9 @@ def test_merge():
     assert t3_n2.typ == n.r @ s
     assert t3_n2.ind == 2
     assert len(t3_n2.children) == 1
+
+
+def test_remove_self_cycles():
+    t5.remove_self_cycles()
+    assert t5_n2.parent is None
+    assert t5_n2_2.children == [t5_n1]

--- a/tests/text2diagram/test_pregroup_tree_converter.py
+++ b/tests/text2diagram/test_pregroup_tree_converter.py
@@ -10,7 +10,7 @@ from lambeq.text2diagram.pregroup_tree_converter import (
 
 tokeniser = SpacyTokeniser()
 bobcat_parser = BobcatParser(verbose='suppress')
-n, s = map(Ty, 'ns')
+n, s, p = map(Ty, 'nsp')
 
 s1 = tokeniser.tokenise_sentence(
     "Last year's figures include a one-time loss of $12 million for restructuring and unusual items"
@@ -98,6 +98,10 @@ s10_diag = Diagram.create_pregroup_diagram(
         (Cup, 1, 6),
         (Cup, 7, 12),
     ]
+)
+s11_diag = bobcat_parser.sentence2diagram(
+    'When an event puts Errol in danger and the case in jeopardy',
+    tokenised=False
 )
 
 t1_n1 = PregroupTreeNode(word='year', typ=n, ind=1)
@@ -191,6 +195,22 @@ t10_n1 = PregroupTreeNode(word='1', typ=n, ind=1, children=[t10_n2])
 t10_n0 = PregroupTreeNode(word='0', typ=s, ind=0, children=[t10_n1])
 t10_no_cycle = t10_n0
 
+t11_n11 = PregroupTreeNode(word='jeopardy', typ=n, ind=11)
+t11_n9 = PregroupTreeNode(word='case', typ=n, ind=9)
+t11_n6 = PregroupTreeNode(word='danger', typ=n, ind=6)
+t11_n4 = PregroupTreeNode(word='Errol', typ=n, ind=4)
+t11_n3 = PregroupTreeNode(word='puts', typ=n.r @ s @ p.l @ n.l, ind=3)
+t11_n2 = PregroupTreeNode(word='event', typ=n, ind=2)
+t11_n10 = PregroupTreeNode(word='in', typ=p, ind=10, children=[t11_n11])
+t11_n8 = PregroupTreeNode(word='the', typ=n, ind=8, children=[t11_n9])
+t11_n5 = PregroupTreeNode(word='in', typ=p, ind=5, children=[t11_n6])
+t11_n1 = PregroupTreeNode(word='an', typ=n, ind=1, children=[t11_n2])
+t11_n7 = PregroupTreeNode(word='and', typ=s, ind=7,
+                          children=[t11_n1, t11_n3, t11_n4,
+                                    t11_n5, t11_n8, t11_n10])
+t11_n0 = PregroupTreeNode(word='When', typ=s, ind=0, children=[t11_n7])
+t11_no_cycle = t11_n0
+
 
 def test_diagram2tree():
     s1_tree = diagram2tree(s1_diag)
@@ -228,6 +248,11 @@ def test_diagram2tree_no_cycles():
     s10_tree.draw()
     t10_no_cycle.draw()
     assert s10_tree == t10_no_cycle
+
+    s11_tree = diagram2tree(s11_diag, break_cycles=True)
+    s11_tree.draw()
+    t11_no_cycle.draw()
+    assert s11_tree == t11_no_cycle
 
 
 def test_tree2diagram():


### PR DESCRIPTION
Fixes #180.

There are two causes to the `KeyError`:
- Self-cycles causing entire branches to be pruned when `break_cycles=True`
- Wrong index for the `''` word placeholder when reindexing. This is fixed by pairing the tokens with their token index, obtained via `tree.get_word_indices()`, instead of just enumerating `tree.get_words()`