### PR TITLE
Fix behavior of `Ty @ Diagram` when diagram is `Id`

### DIFF
--- a/lambeq/backend/grammar.py
+++ b/lambeq/backend/grammar.py
@@ -232,7 +232,7 @@ class Ty(Entity):
 
         # Diagrams are iterable - the identity diagram has
         # an empty list for its layers but may still contain types
-        if isinstance(other, self.category.Diagram) and other.is_id:
+        if getattr(other, 'is_id', False):
             return NotImplemented
 
         if any(not isinstance(ty, type(self))

--- a/lambeq/backend/grammar.py
+++ b/lambeq/backend/grammar.py
@@ -230,6 +230,11 @@ class Ty(Entity):
         except TypeError:
             return NotImplemented
 
+        # Diagrams are iterable - the identity diagram has
+        # an empty list for its layers but may still contain types
+        if isinstance(other, self.category.Diagram) and other.is_id:
+            return NotImplemented
+
         if any(not isinstance(ty, type(self))
                or self.category != ty.category for ty in tys):
             return NotImplemented

--- a/tests/backend/test_grammar.py
+++ b/tests/backend/test_grammar.py
@@ -27,6 +27,7 @@ def test_Ty():
     assert a**1 == a
     assert a**2 == a @ a
     assert a**3 == a @ a @ a
+    assert c @ a == a @ c == a
 
     with raises(TypeError):
         a @ 'b'
@@ -170,12 +171,15 @@ def test_Layer():
 
 def test_Id():
     a, b = map(Ty, 'ab')
+    c = Ty()
     box = Box('dimitri', a, b)
 
     assert box @ Id() == box.to_diagram()
     assert box @ Id(b) >> Id(b) @ box.dagger() == box @ box.dagger()
     assert Id().is_id == True
     assert Id().dagger() == Id()
+    assert Id(a) @ c == Id(a)
+    assert c @ Id(a) == Id(a)
 
 
 def test_Diagram():

--- a/tests/backend/test_grammar.py
+++ b/tests/backend/test_grammar.py
@@ -152,7 +152,6 @@ def test_Spider():
 
 def test_Swap():
     a, b = map(Ty, 'ab')
-    ab = a @ b
 
     swap = Swap(a, b)
     assert swap.dagger().dagger() == swap
@@ -180,6 +179,7 @@ def test_Id():
     assert Id().dagger() == Id()
     assert Id(a) @ c == Id(a)
     assert c @ Id(a) == Id(a)
+    assert a @ b @ Id(b) == Id(a @ b @ b)
 
 
 def test_Diagram():


### PR DESCRIPTION
This fixes the diagram composition issue found with the following sentence:

`"Drama. An astronaut finds himself stranded on a space station in a constant orbit around the Earth. Contact with the outside world is impossible."`.

![image](https://github.com/user-attachments/assets/67057a1f-99af-4ceb-a15a-ebd414e79aa7)
