### PR TITLE
Hide wire labels by default when drawing diagrams with frames

### DIFF
--- a/lambeq/backend/drawing/drawing.py
+++ b/lambeq/backend/drawing/drawing.py
@@ -100,6 +100,8 @@ def draw(diagram: Diagram, **params) -> None:
 
     params['asymmetry'] = params.get(
         'asymmetry', .25 * needs_asymmetry(diagram))
+    default_label_flag = False if diagram.has_frames else True
+    params['draw_type_labels'] = params.get('draw_type_labels', default_label_flag)
 
     drawable = params.pop('drawable', None)
     drawable_cls = (DrawableDiagramWithFrames if diagram.has_frames

--- a/lambeq/backend/drawing/drawing.py
+++ b/lambeq/backend/drawing/drawing.py
@@ -100,7 +100,7 @@ def draw(diagram: Diagram, **params) -> None:
 
     params['asymmetry'] = params.get(
         'asymmetry', .25 * needs_asymmetry(diagram))
-    default_label_flag = False if diagram.has_frames else True
+    default_label_flag = not diagram.has_frames
     params['draw_type_labels'] = params.get('draw_type_labels',
                                             default_label_flag)
 

--- a/lambeq/backend/drawing/drawing.py
+++ b/lambeq/backend/drawing/drawing.py
@@ -100,9 +100,9 @@ def draw(diagram: Diagram, **params) -> None:
 
     params['asymmetry'] = params.get(
         'asymmetry', .25 * needs_asymmetry(diagram))
-    default_label_flag = not diagram.has_frames
+
     params['draw_type_labels'] = params.get('draw_type_labels',
-                                            default_label_flag)
+                                            not diagram.has_frames)
 
     drawable = params.pop('drawable', None)
     drawable_cls = (DrawableDiagramWithFrames if diagram.has_frames

--- a/lambeq/backend/drawing/drawing.py
+++ b/lambeq/backend/drawing/drawing.py
@@ -101,7 +101,8 @@ def draw(diagram: Diagram, **params) -> None:
     params['asymmetry'] = params.get(
         'asymmetry', .25 * needs_asymmetry(diagram))
     default_label_flag = False if diagram.has_frames else True
-    params['draw_type_labels'] = params.get('draw_type_labels', default_label_flag)
+    params['draw_type_labels'] = params.get('draw_type_labels',
+                                            default_label_flag)
 
     drawable = params.pop('drawable', None)
     drawable_cls = (DrawableDiagramWithFrames if diagram.has_frames

--- a/tests/backend/test_frame_drawing.py
+++ b/tests/backend/test_frame_drawing.py
@@ -605,7 +605,7 @@ def test_drawable_generation(diagram, drawable):
 @pytest.mark.parametrize('diagram, tikz', zip(diagrams, tikz_outputs))
 def test_tikz_drawing(diagram, tikz, capsys):
 
-    diagram.draw(backend=TikzBackend(), color_boxes=False)
+    diagram.draw(backend=TikzBackend(), color_boxes=False,  draw_type_labels=True)
     tikz_op, _ = capsys.readouterr()
 
     assert tikz_op == tikz
@@ -614,7 +614,7 @@ def test_tikz_drawing(diagram, tikz, capsys):
 @pytest.mark.parametrize('diagram, tikz', zip(diagrams, colored_tikz_outputs))
 def test_tikz_colored_drawing(diagram, tikz, capsys):
 
-    diagram.draw(backend=TikzBackend(), color_boxes=True)
+    diagram.draw(backend=TikzBackend(), color_boxes=True, draw_type_labels=True)
     tikz_op, _ = capsys.readouterr()
 
     assert tikz_op == tikz


### PR DESCRIPTION
fix address the issue mentioned [here](https://github.com/CQCL-DEV/lambeq-discocirc/issues/35), where the labels displayed in string diagrams by default, but disable in Discocirc  diagrams by default. 

**Code sample:**

```
diagram =  (Word('Alice', n) @ Word('Bob', n) @ Word('cake', n) @ Word('coffee', n)
         >> (Box('told', n @ n, n @ n) @ n @ n)
         >> fr_1
         >> (n @ Box('test', n @ n, n @ n))
         >> (Box('a', n, n) @ n @ Box('b', n, Ty())))
```

Matbackend 

  `diagram.draw(figsize=(12,8))`

Tikz backend 

   `diagram.draw(to_tikz=True, use_tikzstyles=True)`

**Screenshots**

<img width="544" alt="Screenshot 2024-11-18 at 14 17 13" src="https://github.com/user-attachments/assets/be1ad38b-3d23-47a9-a10f-ea52f0efaec5">
<img width="515" alt="Screenshot 2024-11-18 at 14 17 41" src="https://github.com/user-attachments/assets/fd592255-0836-4ab6-b743-890c1604c386">
<img width="1394" alt="Screenshot 2024-11-18 at 14 18 28" src="https://github.com/user-attachments/assets/2a7018ea-ea3e-495a-a53f-0f749ecf41a2">
<img width="1382" alt="Screenshot 2024-11-18 at 14 18 59" src="https://github.com/user-attachments/assets/7663e151-1474-432b-935f-6e70a61bfa4a">

<img width="1015" alt="Screenshot 2024-11-18 at 14 08 55" src="https://github.com/user-attachments/assets/6d02337d-1669-4ffc-90ca-adc8530d69fd">
<img width="1044" alt="Screenshot 2024-11-18 at 14 10 18" src="https://github.com/user-attachments/assets/cc22222d-49cb-4dce-b7ef-e78cbe2beae0">
<img width="497" alt="Screenshot 2024-11-18 at 14 13 41" src="https://github.com/user-attachments/assets/b0fb13d6-7d9e-499a-aba3-57af5da89e65">
<img width="462" alt="Screenshot 2024-11-18 at 14 14 21" src="https://github.com/user-attachments/assets/ef108b0c-bed9-4f7c-8142-1366c611bcf2">
