### PR TITLE
Add custom Symbol class

### DIFF
--- a/lambeq/__init__.py
+++ b/lambeq/__init__.py
@@ -33,6 +33,7 @@ __all__ = [
         'SpiderAnsatz',
         'StronglyEntanglingAnsatz',
         'Symbol',
+        'lambdify',
         'TensorAnsatz',
 
         'CCGType',
@@ -104,10 +105,11 @@ __all__ = [
         'MSELoss',
 ]
 
+from lambeq.backend import Symbol, lambdify
 from lambeq import ansatz, core, rewrite, text2diagram, tokeniser, training
 from lambeq.ansatz import (BaseAnsatz, CircuitAnsatz, IQPAnsatz, MPSAnsatz,
                            Sim14Ansatz, Sim15Ansatz, Sim4Ansatz, SpiderAnsatz,
-                           StronglyEntanglingAnsatz, Symbol, TensorAnsatz)
+                           StronglyEntanglingAnsatz, TensorAnsatz)
 from lambeq.core.globals import VerbosityLevel
 from lambeq.core.types import AtomicType
 from lambeq.rewrite import (CoordinationRewriteRule, CurryRewriteRule,

--- a/lambeq/ansatz/__init__.py
+++ b/lambeq/ansatz/__init__.py
@@ -14,9 +14,9 @@
 
 __all__ = ['BaseAnsatz', 'CircuitAnsatz', 'IQPAnsatz', 'MPSAnsatz',
            'Sim14Ansatz', 'Sim15Ansatz', 'Sim4Ansatz', 'SpiderAnsatz',
-           'StronglyEntanglingAnsatz', 'Symbol', 'TensorAnsatz']
+           'StronglyEntanglingAnsatz', 'TensorAnsatz']
 
-from lambeq.ansatz.base import BaseAnsatz, Symbol
+from lambeq.ansatz.base import BaseAnsatz
 from lambeq.ansatz.circuit import (CircuitAnsatz, IQPAnsatz,
                                    Sim14Ansatz, Sim15Ansatz, Sim4Ansatz,
                                    StronglyEntanglingAnsatz)

--- a/lambeq/ansatz/base.py
+++ b/lambeq/ansatz/base.py
@@ -24,72 +24,9 @@ __all__ = ['BaseAnsatz', 'Symbol']
 
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
-from typing import Any, Literal
-
-import sympy
 
 from lambeq.backend import grammar, tensor
-
-
-class Symbol(sympy.Symbol):
-    """A sympy symbol augmented with extra information.
-
-    Attributes
-    ----------
-    directed_dom : int
-        The size of the domain of the tensor-box that this symbol
-        represents.
-    directed_cod : int
-        The size of the codomain of the tensor-box that this symbol
-        represents.
-    size : int
-        The total size of the tensor that this symbol represents
-        (directed_dom * directed_cod).
-
-    """
-    directed_dom: int
-    directed_cod: int
-
-    def __new__(cls,
-                name: str,
-                directed_dom: int = 1,
-                directed_cod: int = 1,
-                **assumptions: bool) -> Symbol:
-        """Initialise a symbol.
-
-        Parameters
-        ----------
-        directed_dom : int, default: 1
-            The size of the domain of the tensor-box that this symbol
-            represents.
-        directed_cod : int, default: 1
-            The size of the codomain of the tensor-box that this symbol
-            represents.
-
-        """
-        cls._sanitize(assumptions, cls)
-
-        obj: Symbol = sympy.Symbol.__xnew__(cls, name, **assumptions)
-        obj.directed_dom = directed_dom
-        obj.directed_cod = directed_cod
-        return obj
-
-    def __getnewargs_ex__(self) -> tuple[tuple[str, int], dict[str, bool]]:
-        return (self.name, self.size), self.assumptions0
-
-    @property
-    def size(self) -> int:
-        return self.directed_dom * self.directed_cod
-
-    @sympy.cacheit
-    def sort_key(self, order: Literal[None] = None) -> tuple[Any, ...]:
-        return (self.class_key(),
-                (2, (self.name, self.size)),
-                sympy.S.One.sort_key(),
-                sympy.S.One)
-
-    def _hashable_content(self) -> tuple[Any, ...]:
-        return (*super()._hashable_content(), self.size)
+from lambeq.backend.symbol import Symbol
 
 
 class BaseAnsatz(ABC):

--- a/lambeq/ansatz/circuit.py
+++ b/lambeq/ansatz/circuit.py
@@ -35,7 +35,6 @@ from itertools import cycle
 from typing import Type
 
 import numpy as np
-from sympy import Symbol, symbols
 
 from lambeq.ansatz import BaseAnsatz
 from lambeq.backend.grammar import Box, Diagram, Functor, Ty
@@ -52,6 +51,7 @@ from lambeq.backend.quantum import (
     Rotation,
     Rx, Ry, Rz
 )
+from lambeq.backend.symbol import Symbol
 
 computational_basis = Id(qubit)
 
@@ -132,14 +132,15 @@ class CircuitAnsatz(BaseAnsatz):
         if n_qubits == 0:
             circuit = Id()
         elif n_qubits == 1:
-            syms = symbols(f'{label}_0:{self.n_single_qubit_params}',
-                           cls=Symbol)
+            syms = [Symbol(f'{label}_{i}')
+                    for i in range(self.n_single_qubit_params)]
             circuit = Id(qubit)
             for rot, sym in zip(cycle(self.single_qubit_rotations), syms):
                 circuit >>= rot(sym)
         else:
             params_shape = self.params_shape(n_qubits)
-            syms = symbols(f'{label}_0:{np.prod(params_shape)}', cls=Symbol)
+            syms = [Symbol(f'{label}_{i}')
+                    for i in range(np.prod(params_shape))]
             params: np.ndarray = np.array(syms).reshape(params_shape)
             circuit = self.circuit(n_qubits, params)
 

--- a/lambeq/ansatz/tensor.py
+++ b/lambeq/ansatz/tensor.py
@@ -24,8 +24,8 @@ __all__ = ['TensorAnsatz', 'MPSAnsatz', 'SpiderAnsatz']
 
 from collections.abc import Mapping
 
-from lambeq.ansatz import BaseAnsatz, Symbol
-from lambeq.backend import grammar, tensor
+from lambeq.ansatz import BaseAnsatz
+from lambeq.backend import grammar, Symbol, tensor
 from lambeq.backend.grammar import Cup, Spider, Ty, Word
 from lambeq.backend.tensor import Dim
 

--- a/lambeq/backend/__init__.py
+++ b/lambeq/backend/__init__.py
@@ -29,9 +29,12 @@ __all__ = ['Box',
 
            'draw',
            'draw_equation',
-           'to_gif']
+           'to_gif',
+           'Symbol',
+           'lambdify']
 
 from lambeq.backend.grammar import (Box, Cap, Category, Cup, Diagram,
                                     Frame, Functor, Id, Spider, Swap, Ty, Word)
 from lambeq.backend.pregroup_tree import PregroupTreeNode
+from lambeq.backend.symbol import lambdify, Symbol
 from lambeq.backend.drawing import draw, draw_equation, to_gif

--- a/lambeq/backend/pennylane.py
+++ b/lambeq/backend/pennylane.py
@@ -95,9 +95,9 @@ def tk_op_to_pennylane(tk_op):
     :class:`qml.operation.Operation`
         The PennyLane operation equivalent to the input pytket Op.
     list of (:class:`torch.FloatTensor` or
-             :class:`sympy.core.symbol.Symbol`)
+             :class:`lambeq.backend.symbol.Symbol`)
         The parameters of the operation.
-    list of :class:`sympy.core.symbol.Symbol`
+    list of :class:`lambeq.backend.symbol.Symbol`
         The free symbols in the parameters of the operation.
     list of int
         The wires/qubits to apply the operation to.
@@ -137,11 +137,11 @@ def extract_ops_from_tk(tk_circ):
     list of :class:`qml.operation.Operation`
         The PennyLane operations extracted from the pytket circuit.
     list of list of (:class:`torch.FloatTensor` or
-                     :class:`sympy.core.symbol.Symbol`)
+                     :class:`lambeq.backend.symbol.Symbol`)
         The corresponding parameters of the operations.
     list of list of int
         The corresponding wires of the operations.
-    set of :class:`sympy.core.symbol.Symbol`
+    set of :class:`lambeq.backend.symbol.Symbol`
         The free symbols in the parameters of the tket circuit.
 
     """
@@ -250,6 +250,7 @@ STATE_DEVICES = ['aer_simulator_statevector', 'statevector_simulator']
 
 class PennyLaneCircuit:
     """Implement a pennylane circuit with post-selection."""
+
     def __init__(self, ops, symbols, params, wires, probabilities,
                  post_selection, scale, n_qubits, backend_config,
                  diff_method):
@@ -343,7 +344,7 @@ class PennyLaneCircuit:
 
         Parameters
         ----------
-        symbols : list of :class:`sympy.core.symbol.Symbol`, default: None
+        symbols : list of :class:`lambeq.Symbol`, default: None
             The symbols from the original lambeq circuit.
         weights : list of :class:`torch.FloatTensor`, default: None
             The weights to substitute for the symbols.
@@ -468,7 +469,7 @@ class PennyLaneCircuit:
 
         Parameters
         ----------
-        symbols : list of :class:`sympy.core.symbol.Symbol`, default: None
+        symbols : list of :class:`lambeq.Symbol`, default: None
             The symbols from the original lambeq circuit.
         weights : list of :class:`torch.FloatTensor`, default: None
             The weights to substitute for the symbols.

--- a/lambeq/backend/symbol.py
+++ b/lambeq/backend/symbol.py
@@ -1,0 +1,111 @@
+# Copyright 2021-2024 Cambridge Quantum Computing Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+from dataclasses import dataclass
+from typing import Callable, Sequence
+
+import numpy as np
+
+
+@dataclass
+class Symbol:
+    """lambeq symbol supporting multiply, size, hashing and conversion
+    to and from `sympy.Symbol`.
+
+    Attributes
+    ----------
+    name : str
+        Name of the symbol.
+    directed_dom : int
+        The size of the domain of the tensor-box that this symbol
+        represents.
+    directed_cod : int
+        The size of the codomain of the tensor-box that this symbol
+        represents.
+    size : int
+        The total size of the tensor that this symbol represents
+        (directed_dom * directed_cod).
+
+    """
+
+    name: str
+    directed_dom: int = 1
+    directed_cod: int = 1
+    scale: float = 1.0
+
+    def __hash__(self):
+        return hash(self.name)
+
+    def __repr__(self):
+        return self.name if self.scale == 1 else f'{self.scale} {self.name}'
+
+    @property
+    def unscaled(self):
+        return Symbol(self.name, self.directed_dom, self.directed_cod)
+
+    def __mul__(self, other):
+        return Symbol(self.name,
+                      self.directed_dom,
+                      self.directed_cod,
+                      other * self.scale)
+
+    def __rmul__(self, other):
+        return Symbol(self.name,
+                      self.directed_dom,
+                      self.directed_cod,
+                      other * self.scale)
+
+    def __neg__(self):
+        return Symbol(self.name,
+                      self.directed_dom,
+                      self.directed_cod,
+                      -self.scale)
+
+    def to_sympy(self):
+        import sympy
+        # Multiplying by 1.0 changes Symbol to Mul in sympy
+        if self.scale != 1:
+            return self.scale * sympy.Symbol(self.name)
+        return sympy.Symbol(self.name)
+
+    @property
+    def size(self) -> int:
+        return self.directed_dom * self.directed_cod
+
+    def __lt__(self, other):
+        return (self.name, self.scale) < (other.name, other.scale)
+
+
+def lambdify(symbol: Sequence[Symbol],
+             expr: Symbol | float | np.ndarray | None) -> Callable:
+    """
+    Parameters
+    ----------
+    symbol : Sequence of `lambeq.backend.symbol.Symbol`
+        List of symbols in the order in which they will be
+        provided during lambda invocation.
+    expr : `lambeq.backend.symbol.Symbol` or float or None
+        Symbolic expression for which lambda invocation
+        will return the concrete value.
+
+    Returns
+    -------
+    Callable
+        Lambda function for returning evaluation of expr
+
+    """
+    if not isinstance(expr, Symbol):
+        return lambda *_lx: expr
+
+    idx = symbol.index(expr.unscaled)
+    return lambda *lx: expr.scale * lx[idx]

--- a/lambeq/training/model.py
+++ b/lambeq/training/model.py
@@ -24,7 +24,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Collection
 from typing import Any
 
-from sympy import default_sort_key, Symbol as SymPySymbol
+from sympy import Symbol as SymPySymbol
 
 from lambeq.ansatz.base import Symbol
 from lambeq.backend.tensor import Diagram
@@ -48,7 +48,7 @@ class Model(ABC):
 
     def __init__(self) -> None:
         """Initialise an instance of :py:class:`Model` base class."""
-        self.symbols: list[Symbol | SymPySymbol] = []
+        self.symbols: list[Symbol] | list[SymPySymbol] = []
         self.weights: Collection = []
 
     def __call__(self, *args: Any, **kwds: Any) -> Any:
@@ -178,6 +178,6 @@ class Model(ABC):
         """
         model = cls(**kwargs)
         model.symbols = sorted(
-            {sym for circ in diagrams for sym in circ.free_symbols},
-            key=default_sort_key)
+            {sym for circ in diagrams for sym in circ.free_symbols}
+            )
         return model

--- a/lambeq/training/nelder_mead_optimizer.py
+++ b/lambeq/training/nelder_mead_optimizer.py
@@ -35,12 +35,14 @@ to non-stationary points or sub-optimal solutions.
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Mapping
-from typing import Any
+from typing import Any, Set
 import warnings
 
 import numpy as np
 from numpy.typing import ArrayLike
+from sympy import Symbol as SympySymbol
 
+from lambeq.backend.symbol import Symbol
 from lambeq.backend.tensor import Diagram
 from lambeq.core.utils import flatten
 from lambeq.training.optimizer import Optimizer
@@ -284,8 +286,9 @@ class NelderMeadOptimizer(Optimizer):
         parameters = self.model.symbols
 
         # try to extract the relevant parameters from the diagrams
-        relevant_params = set.union(*[diag.free_symbols for diag in diags_gen
-                                      if isinstance(diag, Diagram)])
+        diags = [diag.free_symbols
+                 for diag in diags_gen if isinstance(diag, Diagram)]
+        relevant_params: Set[SympySymbol] | Set[Symbol] = set.union(*diags)
         if not relevant_params:
             relevant_params = set(parameters)
         mask = np.array([int(sym in relevant_params) for sym in parameters])

--- a/lambeq/training/pennylane_model.py
+++ b/lambeq/training/pennylane_model.py
@@ -243,9 +243,10 @@ class PennyLaneModel(Model, torch.nn.Module):
                     diff_method=diff_method, backend_config=backend_config,
                     **kwargs)
 
-        model.symbols = sorted(
-            {sym for circ in diagrams for sym in circ.free_symbols},
-            key=default_sort_key)
+        model.symbols = sorted({sym.unscaled.to_sympy()
+                                for circ in diagrams
+                                for sym in circ.free_symbols},
+                               key=default_sort_key)
         for circ in diagrams:
             assert isinstance(circ, Circuit)
             p_circ = circ.to_pennylane(probabilities=model._probabilities,

--- a/lambeq/training/quantum_model.py
+++ b/lambeq/training/quantum_model.py
@@ -26,10 +26,9 @@ import pickle
 from typing import Any, TYPE_CHECKING
 
 import numpy as np
-from numpy.typing import ArrayLike
-from sympy import lambdify
 
 from lambeq.backend import numerical_backend
+from lambeq.backend.symbol import lambdify
 from lambeq.backend.tensor import Diagram
 from lambeq.training.checkpoint import Checkpoint
 from lambeq.training.model import Model
@@ -59,7 +58,7 @@ class QuantumModel(Model):
         super().__init__()
 
         self._training = False
-        self._train_predictions : list[Any] = []
+        self._train_predictions: list[Any] = []
 
     def _log_prediction(self, y: Any) -> None:
         """Log a prediction of the model."""
@@ -133,7 +132,7 @@ class QuantumModel(Model):
 
     def _fast_subs(self,
                    diagrams: list[Diagram],
-                   weights: Iterable[ArrayLike]) -> list[Diagram]:
+                   weights: Iterable) -> list[Diagram]:
         """Substitute weights into a list of parameterised circuit."""
         parameters = {k: v for k, v in zip(self.symbols, weights)}
         diagrams = pickle.loads(pickle.dumps(diagrams))  # does fast deepcopy
@@ -152,7 +151,6 @@ class QuantumModel(Model):
                                 f'Unknown symbol: {repr(sym)}'
                             ) from e
                     b.data = lambdify(syms, b.data)(*values)  # type: ignore[attr-defined] # noqa: E501
-                    # The name of this box isnt updated correctly
                     del b.free_symbols
         return diagrams
 

--- a/lambeq/training/spsa_optimizer.py
+++ b/lambeq/training/spsa_optimizer.py
@@ -22,11 +22,13 @@ Approximation optimizer.
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Mapping
-from typing import Any
+from typing import Any, Set
 
 import numpy as np
 from numpy.typing import ArrayLike
+from sympy import Symbol as SympySymbol
 
+from lambeq.backend.symbol import Symbol
 from lambeq.backend.tensor import Diagram
 from lambeq.core.utils import flatten
 from lambeq.training.optimizer import Optimizer
@@ -137,12 +139,13 @@ class SPSAOptimizer(Optimizer):
         diags_gen = flatten(diagrams)
 
         # the symbolic parameters
-        parameters = self.model.symbols
+        parameters: list[SympySymbol] | list[Symbol] = self.model.symbols
         x = self.model.weights
 
         # try to extract the relevant parameters from the diagrams
-        relevant_params = set.union(*[diag.free_symbols for diag in diags_gen
-                                      if isinstance(diag, Diagram)])
+        relevant_params: Set[SympySymbol] | Set[Symbol] = set.union(
+            *[diag.free_symbols for diag in diags_gen
+              if isinstance(diag, Diagram)])
         if not relevant_params:
             relevant_params = set(parameters)
         mask = np.array([1 if sym in relevant_params else 0

--- a/tests/backend/test_quantum.py
+++ b/tests/backend/test_quantum.py
@@ -2,10 +2,10 @@ import pytest
 
 import numpy as np
 from pytket.extensions.qiskit import AerBackend
-import sympy
 
 from lambeq.backend.quantum import *
 import lambeq.backend.grammar as grammar
+from lambeq.backend import Symbol
 
 def test_Ty():
 
@@ -75,7 +75,7 @@ def test_conjugate():
 
 def test_lambdify():
 
-    a = sympy.symbols("a")
+    a = Symbol("a")
 
     bx1 = Rx(a)
     bx2 = Ry(-a)

--- a/tests/backend/test_tensor.py
+++ b/tests/backend/test_tensor.py
@@ -1,10 +1,10 @@
 import pytest
 
 import numpy as np
-import sympy
 
 import lambeq.backend.grammar as grammar
 from lambeq.backend.tensor import *
+from lambeq.backend import Symbol
 
 
 def test_Ty():
@@ -73,15 +73,17 @@ def test_functors():
 
 def test_lambdify():
 
-    a,b,c,d = sympy.symbols("a,b,c,d")
-    arr1 = [[a, b], [c, d]]
-    arr2 = [[a, b], [b, a]]
+    arr1 = Symbol('a', directed_dom=2, directed_cod=2)
+    arr2 = Symbol('b', directed_dom=2, directed_cod=2)
+
+    conc_arr1 = np.array([[1, 2], [3, 4]])
+    conc_arr2 = np.array([[1, 2], [2, 1]])
 
     bx1 = Box("A", Dim(2), Dim(2), arr1)
-    bx1_concrete = Box("A", Dim(2), Dim(2), [[1, 2], [3, 4]])
+    bx1_concrete = Box("A", Dim(2), Dim(2), np.array([[1, 2], [3, 4]]))
 
     bx2 = Box("B", Dim(2), Dim(2), arr2)
     bx2_concrete = Box("B", Dim(2), Dim(2), [[1, 2], [2, 1]])
 
-    assert bx1.lambdify(a,b,c,d)(1,2,3,4) == bx1_concrete
-    assert (bx1 >> bx2).lambdify(a,b,c,d)(1,2,3,4) == bx1_concrete >> bx2_concrete
+    assert bx1.lambdify(arr1)(conc_arr1) == bx1_concrete
+    assert (bx1 >> bx2).lambdify(arr1, arr2)(conc_arr1, conc_arr2) == bx1_concrete >> bx2_concrete

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -5,7 +5,7 @@ from lambeq.backend.quantum import (Bra, Diagram as Circuit, Controlled, CRx,
                                     CRz, CX, Discard, H, Ket, qubit, Rx, Ry,
                                     Rz, Sqrt, X, Id)
 from lambeq.backend.converters.tk import from_tk
-from sympy import Symbol as sym
+from lambeq import Symbol as sym
 
 from lambeq import (AtomicType, IQPAnsatz, Sim14Ansatz, Sim15Ansatz,
                     Sim4Ansatz, StronglyEntanglingAnsatz)

--- a/tests/test_symbol.py
+++ b/tests/test_symbol.py
@@ -1,6 +1,6 @@
 import pickle
 
-from lambeq import Symbol
+from lambeq import Symbol, lambdify
 
 
 def test_symbol_equality():
@@ -15,3 +15,82 @@ def test_symbol_equality():
 def test_symbol_pickling():
     x2 = Symbol('x', 2, 2)
     assert pickle.loads(pickle.dumps(x2)) == x2
+
+def test_symbol_creation():
+    s = Symbol('x', 2, 3, 0.5)
+    assert s.name == 'x'
+    assert s.directed_dom == 2
+    assert s.directed_cod == 3
+    assert s.scale == 0.5
+    assert s.size == 6
+
+
+def test_symbol_hash():
+    s1 = Symbol('x')
+    s2 = Symbol('x')
+    s3 = Symbol('y')
+    assert hash(s1) == hash(s2)
+    assert hash(s1) != hash(s3)
+
+    s1 = Symbol('x', 2, 3)
+    s2 = Symbol('x', 3, 6)
+    s3 = Symbol('y', 2, 3)
+
+    assert hash(s1) == hash(s2)
+    assert hash(s1) != hash(s3)
+
+
+def test_symbol_repr():
+    s1 = Symbol('x')
+    s2 = Symbol('x', scale=2)
+    assert repr(s1) == 'x'
+    assert repr(s2) == '2 x'
+
+
+def test_symbol_abs():
+    s1 = Symbol('x', 2, 3, 0.5)
+    s_abs = s1.unscaled
+    assert s_abs.name == 'x'
+    assert s_abs.directed_dom == 2
+    assert s_abs.directed_cod == 3
+    assert s_abs.scale == 1.0
+
+
+def test_symbol_multiplication():
+    s1 = Symbol('x', 2, 3, 0.5)
+    s2 = s1 * 2
+    assert s2.scale == 1.0
+    s3 = 3 * s1
+    assert s3.scale == 1.5
+
+
+def test_symbol_negation():
+    s1 = Symbol('x', 2, 3, 0.5)
+    s_neg = -s1
+    assert s_neg.scale == -0.5
+
+
+def test_symbol_to_sympy():
+    import sympy
+    s1 = Symbol('x')
+    s2 = Symbol('x', scale=2)
+    assert s1.to_sympy() == sympy.Symbol('x')
+    assert s2.to_sympy() == 2 * sympy.Symbol('x')
+
+
+
+def test_lambdify():
+
+    import numpy as np
+    s1 = Symbol('x')
+    s2 = Symbol('y', scale=2).unscaled
+    symbols = [s1, s2]
+
+    expr1 = lambdify(symbols, s1)
+    expr2 = lambdify(symbols, s2)
+
+    vals = [np.array([1, 2]), np.array([1, 2])]
+
+    np.testing.assert_array_equal(expr1(*vals), np.array([1, 2]))
+    np.testing.assert_array_equal(expr2(*vals), np.array([1, 2]))
+

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -3,7 +3,6 @@ import pytest
 from lambeq.backend.grammar import Diagram, Id, Ty, Word
 from lambeq.backend.tensor import Dim
 import numpy as np
-from sympy.core.compatibility import default_sort_key
 import tensornetwork as tn
 
 from lambeq import MPSAnsatz, SpiderAnsatz, TensorAnsatz
@@ -20,7 +19,7 @@ def test_tensor_ansatz_eval(diagram):
     ob_map = {Ty(t): Dim(2) for t in 'abcd'}
     ansatz = TensorAnsatz(ob_map)
     tensor = ansatz(diagram)
-    syms = sorted(tensor.free_symbols, key=default_sort_key)
+    syms = sorted(tensor.free_symbols)
     values = [np.ones(k.size) for k in syms]
     subbed_diagram = tensor.lambdify(*syms)(*values)
     result = subbed_diagram.eval(contractor=tn.contractors.auto)
@@ -47,7 +46,7 @@ def test_mps_ansatz_eval(diagram):
     ob_map = {Ty(t): Dim(4) for t in 'abcd'}
     ansatz = MPSAnsatz(ob_map, bond_dim=1)
     tensor = ansatz(diagram)
-    syms = sorted(tensor.free_symbols, key=default_sort_key)
+    syms = sorted(tensor.free_symbols)
     values = [np.ones(k.size) for k in syms]
     subbed_diagram = tensor.lambdify(*syms)(*values)
     result = subbed_diagram.eval(contractor=tn.contractors.auto)
@@ -71,7 +70,7 @@ def test_spider_ansatz_eval(diagram):
     ob_map = {Ty(t): Dim(4) for t in 'abcd'}
     ansatz = SpiderAnsatz(ob_map)
     tensor = ansatz(diagram)
-    syms = sorted(tensor.free_symbols, key=default_sort_key)
+    syms = sorted(tensor.free_symbols)
     values = [np.ones(k.size) for k in syms]
     subbed_diagram = tensor.lambdify(*syms)(*values)
     result = subbed_diagram.eval(contractor=tn.contractors.auto)

--- a/tests/training/test_numpy_model.py
+++ b/tests/training/test_numpy_model.py
@@ -138,7 +138,7 @@ def test_checkpoint_loading_file_not_found_errors():
 
 
 def test_pickling():
-    phi = Symbol('phi', size=123)
+    phi = Symbol('phi', directed_dom=123)
     diagram = Ket(0, 0) >> CRz(phi) >> H @ H >> CX >> SWAP >> Measure() @ Measure()
 
     deepcopied_diagram = deepcopy(diagram)
@@ -164,6 +164,6 @@ def test_normalise():
 
 def test_fast_subs_error():
     with pytest.raises(KeyError):
-        diag = Ket(0, 0) >> CRz(Symbol('phi', size=123)) >> H @ H >> CX >> SWAP >> Measure() @ Measure()
+        diag = Ket(0, 0) >> CRz(Symbol('phi', directed_dom=123)) >> H @ H >> CX >> SWAP >> Measure() @ Measure()
         model = NumpyModel()
         model._fast_subs([diag], [])

--- a/tests/training/test_pytorch_model.py
+++ b/tests/training/test_pytorch_model.py
@@ -52,14 +52,14 @@ def test_forward():
 
 def test_initialise_weights():
     model = CustomPytorchModel()
-    model.symbols = [Symbol('phi', size=2), Symbol('theta', size=2)]
+    model.symbols = [Symbol('phi', directed_dom=2), Symbol('theta', directed_dom=2)]
     tmp_w = pickle.loads(pickle.dumps(model.fcc.weight))
     model.initialise_weights()
     assert model.weights
     assert not torch.equal(model.fcc.weight, tmp_w)
 
 def test_pickling():
-    phi = Symbol('phi', size=123)
+    phi = Symbol('phi', directed_dom=123)
     diagram = (
         tensor.Box("box1", Dim(2), Dim(2), data=phi)
         >> tensor.Spider(Dim(2), 1, 2)


### PR DESCRIPTION
* Remove sympy Symbols in lambeq backend diagrams.

* Add new `lambeq.Symbol` class supporting scalar multiplication.

* Provide conversion methods between new symbol class and `sympy.Symbol`.

---------

Co-authored-by: Blake Wilson <blake.wilson@quantinuum.com>
Co-authored-by: nikhilkhatri <nikhil.khatri@quantinuum.com>