### PR TITLE
Add mixed-scalar support to `PennyLaneCircuit`

### DIFF
--- a/lambeq/backend/converters/tk.py
+++ b/lambeq/backend/converters/tk.py
@@ -206,7 +206,7 @@ def to_tk(circuit: Diagram):
 
     def remove_ketbra1(_, box: Box) -> Diagram | Box:
         ob_map: dict[Box, Diagram]
-        ob_map = {Ket(1): Ket(0) >> X,
+        ob_map = {Ket(1): Ket(0) >> X,  # type: ignore[dict-item]
                   Bra(1): X >> Bra(0)}  # type: ignore[dict-item]
         return ob_map.get(box, box)
 

--- a/lambeq/backend/converters/tk.py
+++ b/lambeq/backend/converters/tk.py
@@ -204,9 +204,10 @@ def to_tk(circuit: Diagram):
     qubits: list[int] = []
     circuit = circuit.init_and_discard()
 
-    def remove_ket1(_, box: Box) -> Diagram | Box:
+    def remove_ketbra1(_, box: Box) -> Diagram | Box:
         ob_map: dict[Box, Diagram]
-        ob_map = {Ket(1): Ket(0) >> X}  # type: ignore[dict-item]
+        ob_map = {Ket(1): Ket(0) >> X,
+                  Bra(1): X >> Bra(0)}  # type: ignore[dict-item]
         return ob_map.get(box, box)
 
     def prepare_qubits(qubits: list[int],
@@ -313,7 +314,7 @@ def to_tk(circuit: Diagram):
 
     circuit = Functor(target_category=quantum,  # type: ignore [assignment]
                       ob=lambda _, x: x,
-                      ar=remove_ket1)(circuit)  # type: ignore [arg-type]
+                      ar=remove_ketbra1)(circuit)  # type: ignore [arg-type]
     for left, box, _ in circuit:
         if isinstance(box, Ket):
             qubits = prepare_qubits(qubits, box, left.count(qubit))

--- a/lambeq/backend/pennylane.py
+++ b/lambeq/backend/pennylane.py
@@ -42,6 +42,7 @@ associated weights should be passed to `eval()` as `symbols=` and
 from __future__ import annotations
 
 from itertools import product
+import sys
 from typing import TYPE_CHECKING
 
 import pennylane as qml
@@ -220,6 +221,12 @@ def to_pennylane(lambeq_circuit: Diagram, probabilities=False,
     if any(isinstance(box, Measure) for box in lambeq_circuit.boxes):
         raise ValueError('Only pure circuits, or circuits with discards'
                          ' are currently supported.')
+
+    if lambeq_circuit.is_mixed and lambeq_circuit.cod:
+        # Some qubits discarded, some left open
+        print('Warning: Circuit includes both discards and open codomain'
+              ' wires. All open wires will be discarded during conversion',
+              file=sys.stderr)
 
     tk_circ = lambeq_circuit.to_tk()
     op_list, params_list, wires_list, symbols_set = (

--- a/lambeq/backend/pennylane.py
+++ b/lambeq/backend/pennylane.py
@@ -49,7 +49,7 @@ from pytket import OpType
 import sympy
 import torch
 
-from lambeq.backend.quantum import Scalar
+from lambeq.backend.quantum import Scalar, Measure
 
 if TYPE_CHECKING:
     from lambeq.backend.quantum import Diagram
@@ -216,6 +216,10 @@ def to_pennylane(lambeq_circuit: Diagram, probabilities=False,
         The PennyLane circuit equivalent to the input lambeq circuit.
 
     """
+
+    if any(isinstance(box, Measure) for box in lambeq_circuit.boxes):
+        raise ValueError("Only pure circuits, or circuits with discards"
+                          " are currently supported.")
 
     tk_circ = lambeq_circuit.to_tk()
     op_list, params_list, wires_list, symbols_set = (

--- a/lambeq/backend/pennylane.py
+++ b/lambeq/backend/pennylane.py
@@ -49,7 +49,7 @@ from pytket import OpType
 import sympy
 import torch
 
-from lambeq.backend.quantum import Scalar, Measure
+from lambeq.backend.quantum import Measure, Scalar
 
 if TYPE_CHECKING:
     from lambeq.backend.quantum import Diagram
@@ -218,8 +218,8 @@ def to_pennylane(lambeq_circuit: Diagram, probabilities=False,
     """
 
     if any(isinstance(box, Measure) for box in lambeq_circuit.boxes):
-        raise ValueError("Only pure circuits, or circuits with discards"
-                          " are currently supported.")
+        raise ValueError('Only pure circuits, or circuits with discards'
+                         ' are currently supported.')
 
     tk_circ = lambeq_circuit.to_tk()
     op_list, params_list, wires_list, symbols_set = (

--- a/tests/backend/test_pennylane_interface.py
+++ b/tests/backend/test_pennylane_interface.py
@@ -98,6 +98,16 @@ def test_pennylane_circuit_mixed_error():
         snake.to_pennylane()
 
 
+def test_pennylane_circuit_mixed_warning(capsys):
+    bell_state = Diagram.caps(qubit, qubit)
+    bell_discarded = bell_state >> Discard() @ Id(qubit)
+    _ = bell_discarded.to_pennylane()
+    captured = capsys.readouterr()
+    assert captured.err == ('Warning: Circuit includes both discards and open '
+                            'codomain wires. All open wires will be discarded '
+                            'during conversion\n')
+
+
 def test_pennylane_circuit_draw(capsys):
     bell_state = Diagram.caps(qubit, qubit)
     bell_effect = bell_state[::-1]


### PR DESCRIPTION
With this PR we add support for evaluating "mixed-scalar" circuits i.e. circuits where all qubits are either discarded or post-selected.