### PR TITLE
Make `spacy` model version match library version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -88,7 +88,7 @@ experimental =
     numpy == 1.26.4
     spacy ~= 3.4.0
     spacy-experimental ~= 0.6.4
-    en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl
+    en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.4.0/en_core_web_sm-3.4.0-py3-none-any.whl
     en-coreference-web-trf @ https://github.com/explosion/spacy-experimental/releases/download/v0.6.1/en_coreference_web_trf-3.4.0a2-py3-none-any.whl
 
 [options.entry_points]


### PR DESCRIPTION
The version mismatch causes a `RegistryError` as reported by Mina.