### PR TITLE
Fix issues with `NotImplemented` return

### DIFF
--- a/lambeq/backend/grammar.py
+++ b/lambeq/backend/grammar.py
@@ -224,20 +224,22 @@ class Ty(Entity):
     @overload
     def tensor(self, other: Self, *rest: Self) -> Self: ...
 
-    def tensor(self, other: Self | Iterable[Self], *rest: Self) -> Self:
+    def tensor(self,
+               other: Self | Iterable[Self],
+               *rest: Self) -> Self:
         try:
             tys = [*other, *rest]
         except TypeError:
-            return NotImplemented
+            return NotImplemented   # type: ignore[no-any-return]
 
         # Diagrams are iterable - the identity diagram has
         # an empty list for its layers but may still contain types
         if getattr(other, 'is_id', False):
-            return NotImplemented
+            return NotImplemented   # type: ignore[no-any-return]
 
         if any(not isinstance(ty, type(self))
                or self.category != ty.category for ty in tys):
-            return NotImplemented
+            return NotImplemented   # type: ignore[no-any-return]
 
         return self._fromiter(ob for ty in (self, *tys) for ob in ty)
 
@@ -905,7 +907,7 @@ class Diagram(Entity):
         try:
             diags = self.lift([self, *diagrams])
         except ValueError:
-            return NotImplemented
+            return NotImplemented   # type: ignore[no-any-return]
 
         right = dom = self.dom.tensor(*[
             diagram.to_diagram().dom for diagram in diagrams
@@ -964,7 +966,7 @@ class Diagram(Entity):
         try:
             diags = self.lift(diagrams)
         except ValueError:
-            return NotImplemented
+            return NotImplemented   # type: ignore[no-any-return]
 
         layers = [*self.layers]
         cod = self.cod

--- a/lambeq/backend/pregroup_tree.py
+++ b/lambeq/backend/pregroup_tree.py
@@ -123,7 +123,7 @@ class PregroupTreeNode:
         which doesn't check equality of the children - essentially,
         this just checks if `other` is the same token."""
         if not isinstance(other, PregroupTreeNode):
-            return NotImplemented
+            return NotImplemented   # type: ignore[no-any-return]
         return (self.word == other.word
                 and self.ind == other.ind)
 

--- a/lambeq/training/pennylane_model.py
+++ b/lambeq/training/pennylane_model.py
@@ -43,7 +43,7 @@ class PennyLaneModel(Model, torch.nn.Module):
 
     """
 
-    weights: torch.nn.ParameterList
+    weights: torch.nn.ParameterList # type: ignore[assignment]
     symbols: list[Symbol]
 
     def __init__(self,
@@ -131,7 +131,7 @@ class PennyLaneModel(Model, torch.nn.Module):
         """Reinitialise all modules in the model."""
         for module in self.modules():
             try:
-                module.reset_parameters()
+                module.reset_parameters() # type: ignore[operator]
             except (AttributeError, TypeError):
                 pass
 

--- a/lambeq/training/pennylane_model.py
+++ b/lambeq/training/pennylane_model.py
@@ -43,7 +43,7 @@ class PennyLaneModel(Model, torch.nn.Module):
 
     """
 
-    weights: torch.nn.ParameterList # type: ignore[assignment]
+    weights: torch.nn.ParameterList  # type: ignore[assignment]
     symbols: list[Symbol]
 
     def __init__(self,
@@ -131,7 +131,7 @@ class PennyLaneModel(Model, torch.nn.Module):
         """Reinitialise all modules in the model."""
         for module in self.modules():
             try:
-                module.reset_parameters() # type: ignore[operator]
+                module.reset_parameters()  # type: ignore[operator]
             except (AttributeError, TypeError):
                 pass
 

--- a/lambeq/training/pytorch_model.py
+++ b/lambeq/training/pytorch_model.py
@@ -35,7 +35,7 @@ from lambeq.training.model import Model
 class PytorchModel(Model, torch.nn.Module):
     """A lambeq model for the classical pipeline using PyTorch."""
 
-    weights: torch.nn.ParameterList
+    weights: torch.nn.ParameterList # type: ignore[assignment]
     symbols: list[Symbol]
 
     def __init__(self) -> None:
@@ -47,7 +47,7 @@ class PytorchModel(Model, torch.nn.Module):
         """Reinitialise all modules in the model."""
         for module in self.modules():
             try:
-                module.reset_parameters()
+                module.reset_parameters() # type: ignore[operator]
             except (AttributeError, TypeError):
                 pass
 

--- a/lambeq/training/pytorch_model.py
+++ b/lambeq/training/pytorch_model.py
@@ -35,7 +35,7 @@ from lambeq.training.model import Model
 class PytorchModel(Model, torch.nn.Module):
     """A lambeq model for the classical pipeline using PyTorch."""
 
-    weights: torch.nn.ParameterList # type: ignore[assignment]
+    weights: torch.nn.ParameterList  # type: ignore[assignment]
     symbols: list[Symbol]
 
     def __init__(self) -> None:
@@ -47,7 +47,7 @@ class PytorchModel(Model, torch.nn.Module):
         """Reinitialise all modules in the model."""
         for module in self.modules():
             try:
-                module.reset_parameters() # type: ignore[operator]
+                module.reset_parameters()  # type: ignore[operator]
             except (AttributeError, TypeError):
                 pass
 


### PR DESCRIPTION
The behavior of `mypy` with `NotImplemented` has been changed recently (see https://github.com/python/mypy/pull/17890). The affected methods are non-dunder methods from the `lambeq.backend.grammar` module.