### PR TITLE
Fix `lambdify` for `tensor.Daggered`

### DIFF
--- a/lambeq/backend/tensor.py
+++ b/lambeq/backend/tensor.py
@@ -601,6 +601,10 @@ class Daggered(grammar.Daggered, Box):
         if __name == 'data':
             self.box.data = __value
         return super().__setattr__(__name, __value)
+    
+    def lambdify(self, *symbols: 'Symbol', **kwargs) -> Callable:
+        b_fn = self.box.lambdify(*symbols, **kwargs)
+        return lambda *xs: b_fn(*xs).dagger()
 
     @property
     def array(self):
@@ -608,3 +612,4 @@ class Daggered(grammar.Daggered, Box):
 
     __hash__ = Box.__hash__
     __repr__ = Box.__repr__
+    __eq__ = grammar.Daggered.__eq__

--- a/lambeq/backend/tensor.py
+++ b/lambeq/backend/tensor.py
@@ -601,7 +601,7 @@ class Daggered(grammar.Daggered, Box):
         if __name == 'data':
             self.box.data = __value
         return super().__setattr__(__name, __value)
-    
+
     def lambdify(self, *symbols: 'Symbol', **kwargs) -> Callable:
         b_fn = self.box.lambdify(*symbols, **kwargs)
         return lambda *xs: b_fn(*xs).dagger()

--- a/tests/backend/test_tensor.py
+++ b/tests/backend/test_tensor.py
@@ -87,3 +87,12 @@ def test_lambdify():
 
     assert bx1.lambdify(arr1)(conc_arr1) == bx1_concrete
     assert (bx1 >> bx2).lambdify(arr1, arr2)(conc_arr1, conc_arr2) == bx1_concrete >> bx2_concrete
+
+    dg1 = Daggered(bx1)
+    dg1_concrete = Daggered(bx1_concrete)
+
+    dg2 = Daggered(bx2)
+    dg2_concrete = Daggered(bx2_concrete)
+    
+    assert dg1.lambdify(arr1)(conc_arr1) == dg1_concrete
+    assert (dg1 >> dg2).lambdify(arr1, arr2)(conc_arr1, conc_arr2) == dg1_concrete >> dg2_concrete


### PR DESCRIPTION
Solves issue #206 by defining a `lambdify` method to `tensor.Daggered`.  The idea is to apply `lambdify` to the underlying `box` of the `Daggered` and then promoting the result to `tensor.Daggered`, which is inspired by how [`quantum.Controlled.lambdify`](https://github.com/CQCL/lambeq/blob/b0e5765531c12d2e2269056b0f29fe01944f5574/lambeq/backend/quantum.py#L932) is handled.

This example mentioned in #206 no longer produces the error.