### PR TITLE
Include doctests to workflow

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -73,10 +73,10 @@ jobs:
     - name: Test with pytest
       run: >
         coverage run --source=${{ env.SRC_DIR }}
-        --module pytest -vvv ${{ env.TEST_DIR }}
+        --module pytest ${{ env.SRC_DIR }} ${{ env.TEST_DIR }}
+        --doctest-modules
         --durations=50
         --ignore=${{ env.TEST_DIR }}/text2diagram/test_depccg_parser.py
-        --ignore=${{ env.TEST_DIR }}/training/test_torchquantum_model.py
     - name: Coverage report
       run: coverage report -m
   type_check:


### PR DESCRIPTION
The current workflow doesn't check the docstrings that become part of the docs. This may lead to unexpected behavior for users. This also removes a reference to a non-existent file.