### PR TITLE
Pregroup trees: Fix order of atomic types for `n.r @ s @ s.l @ n`

### DIFF
--- a/lambeq/backend/grammar.py
+++ b/lambeq/backend/grammar.py
@@ -26,11 +26,12 @@ from collections.abc import Callable, Iterable, Iterator
 from copy import deepcopy
 from dataclasses import dataclass, field, InitVar, replace
 import json
-import pickle
 from typing import Any, ClassVar, Dict, Protocol, Type, TypeVar
 from typing import cast, overload, TYPE_CHECKING
 
 from typing_extensions import Self
+
+from lambeq.core.utils import fast_deepcopy
 
 
 if TYPE_CHECKING:
@@ -2028,8 +2029,8 @@ class Functor:
         """Apply the functor to a type, caching the result."""
         try:
             # Faster deepcopy
-            return pickle.loads(    # type: ignore[no-any-return]
-                pickle.dumps(self.ob_cache[ob])
+            return fast_deepcopy(    # type: ignore[no-any-return]
+                self.ob_cache[ob]
             )
         except KeyError:
             pass
@@ -2046,8 +2047,8 @@ class Functor:
         """Apply the functor to a diagrammable, caching the result."""
         try:
             # Faster deepcopy
-            return pickle.loads(    # type: ignore[no-any-return]
-                pickle.dumps(self.ar_cache[ar])
+            return fast_deepcopy(    # type: ignore[no-any-return]
+                self.ar_cache[ar]
             )
         except KeyError:
             pass

--- a/lambeq/backend/pregroup_tree.py
+++ b/lambeq/backend/pregroup_tree.py
@@ -104,6 +104,9 @@ class PregroupTreeNode:
         """Return the string representation of the node."""
         return f'{self.word}_{self.ind} ({self.typ})'
 
+    def __lt__(self, other: 'PregroupTreeNode') -> bool:
+        return self.ind < other.ind
+
     def __eq__(self, other: object) -> bool:
         """Check if these are the same instances, including
         the children and parent."""
@@ -114,7 +117,7 @@ class PregroupTreeNode:
                 and self.typ == other.typ
                 and ((self.parent.ind if self.parent else None)
                      == (other.parent.ind if other.parent else None))
-                and self.children == other.children)
+                and sorted(self.children) == sorted(other.children))
 
     def is_same_word(self, other: object) -> bool:
         """Check if these words are the same words in the sentence.

--- a/lambeq/backend/pregroup_tree.py
+++ b/lambeq/backend/pregroup_tree.py
@@ -107,6 +107,9 @@ class PregroupTreeNode:
     def __lt__(self, other: 'PregroupTreeNode') -> bool:
         return self.ind < other.ind
 
+    def __gt__(self, other: 'PregroupTreeNode') -> bool:
+        return self.ind > other.ind
+
     def __eq__(self, other: object) -> bool:
         """Check if these are the same instances, including
         the children and parent."""

--- a/lambeq/core/utils.py
+++ b/lambeq/core/utils.py
@@ -14,11 +14,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Iterator, Mapping
 from math import floor
+import pickle
 from typing import Any, List, Union
 
-from lambeq.backend.grammar import Diagram
 
 SentenceType = Union[str, List[str]]
 SentenceBatchType = Union[List[str], List[List[str]]]
@@ -37,30 +36,6 @@ def untokenised_batch_type_check(sentence: SentenceBatchType) -> bool:
 def tokenised_batch_type_check(batch: SentenceBatchType) -> bool:
     return isinstance(batch, list) and all(
             tokenised_sentence_type_check(s) for s in batch)
-
-
-def flatten(diagrams: Iterable[Any]) -> Iterator[Diagram]:
-    """Flatten a nested iterator of diagrams into a single iterator.
-
-    Parameters
-    ----------
-    diagrams : Iterable
-        Nested iterator containing diagrams.
-
-    Yields
-    ------
-    iterator of Diagram
-        Iterator where each element is a single diagram.
-
-    """
-
-    for d in diagrams:
-        if isinstance(d, Diagram):
-            yield d
-        elif isinstance(d, Mapping):
-            yield from flatten(d.values())
-        elif isinstance(d, Iterable):
-            yield from flatten(d)
 
 
 def normalise_duration(duration_secs: float | None) -> str:
@@ -112,3 +87,8 @@ def normalise_duration(duration_secs: float | None) -> str:
         out.append(f'{secs:.2f}s')
 
     return ''.join(out)
+
+
+def fast_deepcopy(obj: Any) -> Any:
+    """Fast deepcopy (faster than `copy.deepcopy`)."""
+    return pickle.loads(pickle.dumps(obj))

--- a/lambeq/text2diagram/pregroup_tree_converter.py
+++ b/lambeq/text2diagram/pregroup_tree_converter.py
@@ -12,7 +12,6 @@
 # implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-from copy import deepcopy
 from typing import Any, Optional
 
 import networkx as nx
@@ -21,7 +20,7 @@ from lambeq.backend.grammar import Cap, Cup, Diagram, Swap, Ty, Word
 from lambeq.backend.pregroup_tree import (
     PregroupTreeNode, ROOT_INDEX,
 )
-
+from lambeq.core.utils import fast_deepcopy
 
 WordComponentsDictsType = list[dict[int, list[int]]]
 WordComponentsType = list[list[tuple[int, Ty]]]
@@ -641,8 +640,8 @@ def _fix_auxiliary_types(
 
     """
 
-    word_components_dicts = deepcopy(word_components_dicts_orig)
-    word_components = deepcopy(word_components_orig)
+    word_components_dicts = fast_deepcopy(word_components_dicts_orig)
+    word_components = fast_deepcopy(word_components_orig)
 
     # Checks for the type `n.r @ s @ ...` for a word and
     # preserves that ordering for the atomic types

--- a/lambeq/text2diagram/pregroup_tree_converter.py
+++ b/lambeq/text2diagram/pregroup_tree_converter.py
@@ -770,9 +770,9 @@ def tree2diagram(
                                  in word_components_dicts[i].values()])
                 for component in word_components[i]:
                     end_ind = start_ind + len(component[1])
-                    word_components_dict[component[0]] = range(
+                    word_components_dict[component[0]] = list(range(
                         start_ind, end_ind
-                    )
+                    ))
                     start_ind = end_ind
 
                 word_components_dicts[i] = word_components_dict

--- a/lambeq/text2diagram/pregroup_tree_converter.py
+++ b/lambeq/text2diagram/pregroup_tree_converter.py
@@ -12,6 +12,7 @@
 # implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+from copy import deepcopy
 from typing import Any, Optional
 
 import networkx as nx
@@ -20,6 +21,10 @@ from lambeq.backend.grammar import Cap, Cup, Diagram, Swap, Ty, Word
 from lambeq.backend.pregroup_tree import (
     PregroupTreeNode, ROOT_INDEX,
 )
+
+
+WordComponentsDictsType = list[dict[int, list[int]]]
+WordComponentsType = list[list[tuple[int, Ty]]]
 
 
 def diagram2tree(diagram: Diagram,
@@ -626,6 +631,59 @@ def generate_tree(
     return root_nodes, nodes
 
 
+def _fix_auxiliary_types(
+        word_components_dicts_orig: WordComponentsDictsType,
+        word_components_orig: WordComponentsType
+        ) -> tuple[WordComponentsDictsType, WordComponentsType]:
+    """
+    Modifies `word_components_dicts_orig` and `word_components_orig`
+    to return the correct type for auxiliary verbs.
+
+    """
+
+    word_components_dicts = deepcopy(word_components_dicts_orig)
+    word_components = deepcopy(word_components_orig)
+
+    # Checks for the type `n.r @ s @ ...` for a word and
+    # preserves that ordering for the atomic types
+    for i, word_component in enumerate(word_components):
+        if len(word_component) == 2 and i < len(word_components) - 1:
+            # Conditions
+            conditions = [
+                # 2nd half of compound type is 'n.r @ s'
+                str(word_component[1][1] == 'n.r @ s'),
+                # 1st half of compound type connects
+                # to the right of the word
+                word_component[0][0] > i,
+                # There's a next word and is connected to this word
+                # through the 'n.r @ s' type
+                (len(word_components[i + 1]) > 0
+                 and word_components[i + 1][0][0] == i
+                 and str(word_components[i + 1][0][1]) == 's.r @ n.r.r'),
+            ]
+            if all(conditions):
+                word_component[0], word_component[1] = (
+                    word_component[1], word_component[0]
+                )
+                word_components[i] = word_component
+
+                word_components_dict = {}
+                assert len(word_components_dicts[i]) == 2
+                start_ind = min([min(inds)
+                                 for inds
+                                 in word_components_dicts[i].values()])
+                for component in word_components[i]:
+                    end_ind = start_ind + len(component[1])
+                    word_components_dict[component[0]] = list(range(
+                        start_ind, end_ind
+                    ))
+                    start_ind = end_ind
+
+                word_components_dicts[i] = word_components_dict
+
+    return word_components_dicts, word_components
+
+
 def tree2diagram(
     root: PregroupTreeNode,
     tokens: list[str],
@@ -660,7 +718,7 @@ def tree2diagram(
     curr_nodes = [root]
     next_nodes = []
 
-    word_components: list[list[tuple[int, Ty]]] = [
+    word_components: WordComponentsType = [
         [] for _ in range(len(tokens))
     ]
     word_components[root.ind] = [(-1, root.typ)]
@@ -720,7 +778,7 @@ def tree2diagram(
         next_nodes = []
 
     # Derive morphisms from `word_components`
-    word_components_dicts: list[dict[int, list[int]]] = [
+    word_components_dicts: WordComponentsDictsType = [
         {} for _ in range(len(tokens))
     ]
     ty_global_index = 0
@@ -740,42 +798,12 @@ def tree2diagram(
             if other_node_ind == -1:
                 free_wires = list(subword_ty_global_inds)
 
-    # Checks for the type `n.r @ s @ ...` for a word and
-    # preserves that ordering for the atomic types
-    for i, word_component in enumerate(word_components):
-        if len(word_component) == 2 and i < len(word_components) - 1:
-            # Conditions
-            conditions = [
-                # 2nd half of compound type is 'n.r @ s'
-                str(word_component[1][1] == 'n.r @ s'),
-                # 1st half of compound type connects
-                # to the right of the word
-                word_component[0][0] > i,
-                # There's a next word and is connected to this word
-                # through the 'n.r @ s' type
-                (len(word_components[i + 1]) > 0
-                 and word_components[i + 1][0][0] == i
-                 and str(word_components[i + 1][0][1]) == 's.r @ n.r.r'),
-            ]
-            if all(conditions):
-                word_component[0], word_component[1] = (
-                    word_component[1], word_component[0]
-                )
-                word_components[i] = word_component
-
-                word_components_dict = {}
-                assert len(word_components_dicts[i]) == 2
-                start_ind = min([min(inds)
-                                 for inds
-                                 in word_components_dicts[i].values()])
-                for component in word_components[i]:
-                    end_ind = start_ind + len(component[1])
-                    word_components_dict[component[0]] = list(range(
-                        start_ind, end_ind
-                    ))
-                    start_ind = end_ind
-
-                word_components_dicts[i] = word_components_dict
+    # Perform type-related surgery before deriving
+    # the final set of morphisms
+    word_components_dicts, word_components = _fix_auxiliary_types(
+        word_components_dicts,
+        word_components,
+    )
 
     morphisms = []
     for (start_word_ind, end_word_ind) in compound_cups:

--- a/lambeq/training/dataset.py
+++ b/lambeq/training/dataset.py
@@ -20,11 +20,12 @@ A module containing a Dataset class for training lambeq models.
 """
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator, Mapping
 from math import ceil
 import random
 from typing import Any
 
+from lambeq.backend.grammar import Diagram
 from lambeq.backend.numerical_backend import get_backend
 
 
@@ -132,3 +133,27 @@ class Dataset:
         random.shuffle(joint_list)
         data_tuple, targets_tuple = zip(*joint_list)
         return list(data_tuple), list(targets_tuple)
+
+
+def flatten(diagrams: Iterable[Any]) -> Iterator[Diagram]:
+    """Flatten a nested iterator of diagrams into a single iterator.
+
+    Parameters
+    ----------
+    diagrams : Iterable
+        Nested iterator containing diagrams.
+
+    Yields
+    ------
+    iterator of Diagram
+        Iterator where each element is a single diagram.
+
+    """
+
+    for d in diagrams:
+        if isinstance(d, Diagram):
+            yield d
+        elif isinstance(d, Mapping):
+            yield from flatten(d.values())
+        elif isinstance(d, Iterable):
+            yield from flatten(d)

--- a/lambeq/training/nelder_mead_optimizer.py
+++ b/lambeq/training/nelder_mead_optimizer.py
@@ -44,7 +44,7 @@ from sympy import Symbol as SympySymbol
 
 from lambeq.backend.symbol import Symbol
 from lambeq.backend.tensor import Diagram
-from lambeq.core.utils import flatten
+from lambeq.training.dataset import flatten
 from lambeq.training.optimizer import Optimizer
 from lambeq.training.quantum_model import QuantumModel
 

--- a/lambeq/training/quantum_model.py
+++ b/lambeq/training/quantum_model.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from collections.abc import Iterable
-import pickle
 from typing import Any
 
 import numpy as np
@@ -30,6 +29,7 @@ import numpy as np
 from lambeq.backend import numerical_backend
 from lambeq.backend.symbol import lambdify
 from lambeq.backend.tensor import Diagram
+from lambeq.core.utils import fast_deepcopy
 from lambeq.training.checkpoint import Checkpoint
 from lambeq.training.model import Model
 from lambeq.typing import AnyTensor
@@ -134,7 +134,7 @@ class QuantumModel(Model):
                    weights: Iterable) -> list[Diagram]:
         """Substitute weights into a list of parameterised circuit."""
         parameters = {k: v for k, v in zip(self.symbols, weights)}
-        diagrams = pickle.loads(pickle.dumps(diagrams))  # does fast deepcopy
+        diagrams = fast_deepcopy(diagrams)      # does fast deepcopy
         for diagram in diagrams:
             for b in diagram.boxes:
                 if b.free_symbols:

--- a/lambeq/training/quantum_model.py
+++ b/lambeq/training/quantum_model.py
@@ -134,7 +134,7 @@ class QuantumModel(Model):
                    weights: Iterable) -> list[Diagram]:
         """Substitute weights into a list of parameterised circuit."""
         parameters = {k: v for k, v in zip(self.symbols, weights)}
-        diagrams = fast_deepcopy(diagrams)      # does fast deepcopy
+        diagrams = fast_deepcopy(diagrams)
         for diagram in diagrams:
             for b in diagram.boxes:
                 if b.free_symbols:

--- a/lambeq/training/spsa_optimizer.py
+++ b/lambeq/training/spsa_optimizer.py
@@ -30,7 +30,7 @@ from sympy import Symbol as SympySymbol
 
 from lambeq.backend.symbol import Symbol
 from lambeq.backend.tensor import Diagram
-from lambeq.core.utils import flatten
+from lambeq.training.dataset import flatten
 from lambeq.training.optimizer import Optimizer
 from lambeq.training.quantum_model import QuantumModel
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -77,6 +77,8 @@ extras =
     pennylane-qiskit
     pytket >= 1.31.0
     pytket-qiskit >= 0.21.0
+    qiskit-aer < 0.17.0
+    qiskit-ibm-runtime < 0.37.0
     tensorboard >= 2.7.0
     tqdm
 

--- a/tests/backend/test_pregroup_tree.py
+++ b/tests/backend/test_pregroup_tree.py
@@ -53,6 +53,21 @@ t5_n0 = PregroupTreeNode(word='when', typ=s, ind=0, children=[t5_n2_2])
 t5 = t5_n0
 
 
+def test_eq():
+    t1_n1 = PregroupTreeNode(word='t1', typ=Ty(), ind=1)
+    t1_n2 = PregroupTreeNode(word='t2', typ=Ty(), ind=2)
+    t1_n0 = PregroupTreeNode(word='t0', typ=Ty(), ind=0,
+                              children=[t1_n1, t1_n2])
+    t1 = t1_n0
+
+    t2_n1 = PregroupTreeNode(word='t1', typ=Ty(), ind=1)
+    t2_n2 = PregroupTreeNode(word='t2', typ=Ty(), ind=2)
+    t2_n0 = PregroupTreeNode(word='t0', typ=Ty(), ind=0,
+                              children=[t2_n2, t2_n1])
+    t2 = t2_n0
+    assert t1 == t2
+
+
 def test_get_nodes():
     assert t1.get_nodes() == [
         [t1_n0],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,11 @@
 import pytest
 
-from lambeq.core.utils import (normalise_duration,
+from lambeq.core.utils import (fast_deepcopy,
+                               normalise_duration,
                                tokenised_batch_type_check,
                                tokenised_sentence_type_check,
                                untokenised_batch_type_check)
+
 
 @pytest.fixture
 def sentence():
@@ -35,3 +37,34 @@ def test_normalise_duration():
     assert normalise_duration(0.29182375) == '0.29s'
     assert normalise_duration(0.29682375) == '0.30s'
     assert normalise_duration(None) == 'None'
+
+
+class A():
+    def __init__(self, d) -> None:
+        self.a = 1
+        self.b = 'test'
+        self.c = 3.14
+        self.d = d
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, A):
+            return NotImplemented
+        return all([self.a == other.a,
+                    self.b == other.b,
+                    self.c == other.c,
+                    self.d == other.d])
+
+    def __repr__(self) -> str:
+        return f'a={self.a}, b={self.b}, c={self.c}, d={self.d}'
+
+
+@pytest.mark.parametrize('obj', [
+    [1, 'test', 3.14, {10, 20}, {'a': 'b'}],
+    {'a': 0, 'b': 1, 'c': [3, 5, 42.]},
+    A(d={'a': 0, 'b': 1}),
+    [A(d=None), A(d=[1, 2, 3])],
+    {'a': A(d=None), 'b': A(d=[1, 2, 3])}
+])
+def test_fast_deepcopy(obj):
+    print(f'{fast_deepcopy(obj) = }')
+    assert obj == fast_deepcopy(obj)

--- a/tests/text2diagram/test_pregroup_tree_converter.py
+++ b/tests/text2diagram/test_pregroup_tree_converter.py
@@ -17,6 +17,7 @@ s1 = tokeniser.tokenise_sentence(
 )
 s2 = tokeniser.tokenise_sentence('Do your homework')
 s3 = tokeniser.tokenise_sentence('I like but Mary dislikes reading')
+s12 = tokeniser.tokenise_sentence("i don't like it")
 
 s1_diag = bobcat_parser.sentence2diagram(s1, tokenised=True)
 s2_diag = bobcat_parser.sentence2diagram(s2, tokenised=True)
@@ -103,6 +104,7 @@ s11_diag = bobcat_parser.sentence2diagram(
     'When an event puts Errol in danger and the case in jeopardy',
     tokenised=False
 )
+s12_diag = bobcat_parser.sentence2diagram(s12, tokenised=True)
 
 t1_n1 = PregroupTreeNode(word='year', typ=n, ind=1)
 t1_n3 = PregroupTreeNode(word='figures', typ=n, ind=3)
@@ -211,6 +213,13 @@ t11_n7 = PregroupTreeNode(word='and', typ=s, ind=7,
 t11_n0 = PregroupTreeNode(word='When', typ=s, ind=0, children=[t11_n7])
 t11_no_cycle = t11_n0
 
+t12_n4 = PregroupTreeNode(word='it', typ=n, ind=4)
+t12_n0 = PregroupTreeNode(word='i', typ=n, ind=0)
+t12_n3 = PregroupTreeNode(word='like', typ=n.r @ s, ind=3, children=[t12_n4])
+t12_n1 = PregroupTreeNode(word='do', typ=n.r @ s, ind=1, children=[t12_n3])
+t12_n2 = PregroupTreeNode(word="n't", typ=s, ind=2, children=[t12_n0, t12_n1])
+t12 = t12_n2
+
 
 def test_diagram2tree():
     s1_tree = diagram2tree(s1_diag)
@@ -263,7 +272,7 @@ def test_tree2diagram():
     assert tree2diagram(t5, t5.get_words()).pregroup_normal_form() == s5_diag.pregroup_normal_form()
     assert tree2diagram(t6, t6.get_words()).pregroup_normal_form() == s6_diag.pregroup_normal_form()
     assert tree2diagram(t7, t7.get_words()).pregroup_normal_form() == s6_diag.pregroup_normal_form()
-
+    assert tree2diagram(t12, t12.get_words()).pregroup_normal_form() == s12_diag.pregroup_normal_form()
 
 def test_generate_tree():
     # valid diagram

--- a/tests/text2diagram/test_pregroup_tree_converter.py
+++ b/tests/text2diagram/test_pregroup_tree_converter.py
@@ -18,6 +18,7 @@ s1 = tokeniser.tokenise_sentence(
 s2 = tokeniser.tokenise_sentence('Do your homework')
 s3 = tokeniser.tokenise_sentence('I like but Mary dislikes reading')
 s12 = tokeniser.tokenise_sentence("i don't like it")
+s13 = tokeniser.tokenise_sentence("i haven't seen it")
 
 s1_diag = bobcat_parser.sentence2diagram(s1, tokenised=True)
 s2_diag = bobcat_parser.sentence2diagram(s2, tokenised=True)
@@ -105,6 +106,7 @@ s11_diag = bobcat_parser.sentence2diagram(
     tokenised=False
 )
 s12_diag = bobcat_parser.sentence2diagram(s12, tokenised=True)
+s13_diag = bobcat_parser.sentence2diagram(s13, tokenised=True)
 
 t1_n1 = PregroupTreeNode(word='year', typ=n, ind=1)
 t1_n3 = PregroupTreeNode(word='figures', typ=n, ind=3)
@@ -220,6 +222,13 @@ t12_n1 = PregroupTreeNode(word='do', typ=n.r @ s, ind=1, children=[t12_n3])
 t12_n2 = PregroupTreeNode(word="n't", typ=s, ind=2, children=[t12_n0, t12_n1])
 t12 = t12_n2
 
+t13_n4 = PregroupTreeNode(word='it', typ=n, ind=4)
+t13_n0 = PregroupTreeNode(word='i', typ=n, ind=0)
+t13_n3 = PregroupTreeNode(word='seen', typ=n.r @ s, ind=3, children=[t13_n4])
+t13_n1 = PregroupTreeNode(word='have', typ=n.r @ s, ind=1, children=[t13_n3])
+t13_n2 = PregroupTreeNode(word="n't", typ=s, ind=2, children=[t13_n0, t13_n1])
+t13 = t13_n2
+
 
 def test_diagram2tree():
     s1_tree = diagram2tree(s1_diag)
@@ -273,6 +282,7 @@ def test_tree2diagram():
     assert tree2diagram(t6, t6.get_words()).pregroup_normal_form() == s6_diag.pregroup_normal_form()
     assert tree2diagram(t7, t7.get_words()).pregroup_normal_form() == s6_diag.pregroup_normal_form()
     assert tree2diagram(t12, t12.get_words()).pregroup_normal_form() == s12_diag.pregroup_normal_form()
+    assert tree2diagram(t13, t13.get_words()).pregroup_normal_form() == s13_diag.pregroup_normal_form()
 
 def test_generate_tree():
     # valid diagram

--- a/tests/training/test_dataset.py
+++ b/tests/training/test_dataset.py
@@ -4,11 +4,15 @@ import pytest
 import numpy as np
 
 from lambeq import Dataset
+from lambeq.backend.grammar import Cup, Diagram, Ty, Word
+from lambeq.training.dataset import flatten
+
 
 data = [1, 2, 3, 4]
 targets = [5, 6, 7, 8]
 
 random.seed(0)
+
 
 def test_get_item():
     dataset = Dataset(data, targets, batch_size=2, shuffle=False)
@@ -55,3 +59,17 @@ def test_shuffle():
 def test_data_label_length_mismatch():
     with pytest.raises(ValueError):
         _ = Dataset(data, targets[:-1], batch_size=2, shuffle=False)
+
+
+def test_flatten():
+    n, s = Ty('n'), Ty('s')
+    words = [Word('she', n), Word('goes', n.r @ s @ n.l), Word('home', n)]
+    morphisms = [(Cup, 0, 1), (Cup, 3, 4)]
+    diagram = Diagram.create_pregroup_diagram(words, morphisms)
+
+    assert list(flatten([
+        diagram,
+        [diagram, diagram],
+        {'0': diagram},
+        diagram,
+    ])) == [diagram, diagram, diagram, diagram, diagram]

--- a/tests/training/test_pennylane_model.py
+++ b/tests/training/test_pennylane_model.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 from unittest.mock import mock_open, patch
 
 import numpy as np
-from qiskit_ibm_provider.exceptions import IBMAccountError
+from qiskit_ibm_runtime.exceptions import IBMAccountError
 from sympy import default_sort_key
 import torch
 from torch import Size

--- a/tests/training/test_pennylane_model.py
+++ b/tests/training/test_pennylane_model.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 from unittest.mock import mock_open, patch
 
 import numpy as np
-from qiskit_ibm_runtime.exceptions import IBMAccountError
+from qiskit_ibm_provider.exceptions import IBMAccountError
 from sympy import default_sort_key
 import torch
 from torch import Size

--- a/tests/training/test_pytorch_quantum_model.py
+++ b/tests/training/test_pytorch_quantum_model.py
@@ -10,6 +10,7 @@ from lambeq.backend.quantum import CRz, CX, H, Ket, Measure, SWAP, Discard, qubi
 
 from lambeq import AtomicType, IQPAnsatz, PytorchQuantumModel, Symbol
 
+
 def test_init():
     N = AtomicType.NOUN
     S = AtomicType.SENTENCE
@@ -20,6 +21,7 @@ def test_init():
     model.initialise_weights()
     assert len(model.weights) == 4
     assert isinstance(model.weights, torch.nn.Parameter)
+
 
 def test_forward():
     N = AtomicType.NOUN
@@ -33,6 +35,7 @@ def test_forward():
     pred = model.forward(diagrams)
     assert pred.shape == (len(diagrams), s_dim)
 
+
 def test_forward_mixed():
     N = AtomicType.NOUN
     S = AtomicType.SENTENCE
@@ -44,7 +47,7 @@ def test_forward_mixed():
     model.initialise_weights()
     pred = model.forward(diagrams)
     assert pred.shape == (len(diagrams), *density_matrix_dim)
-    
+
 
 def test_backward():
     N = AtomicType.NOUN
@@ -66,6 +69,7 @@ def test_initialise_weights_error():
         model = PytorchQuantumModel()
         model.initialise_weights()
 
+
 def test_get_diagram_output_error():
     N = AtomicType.NOUN
     S = AtomicType.SENTENCE
@@ -74,6 +78,7 @@ def test_get_diagram_output_error():
     with pytest.raises(KeyError):
         model = PytorchQuantumModel()
         model.get_diagram_output([diagram])
+
 
 def test_checkpoint_loading():
     N = AtomicType.NOUN
@@ -94,6 +99,7 @@ def test_checkpoint_loading():
         assert torch.allclose(model([diagram]), model_new([diagram]))
         m.assert_called_with('model.lt', 'rb')
 
+
 def test_checkpoint_loading_errors():
     checkpoint = {'model_weights': np.array([1,2,3])}
     with patch('lambeq.training.checkpoint.open', mock_open(read_data=pickle.dumps(checkpoint))) as m, \
@@ -101,6 +107,7 @@ def test_checkpoint_loading_errors():
         with pytest.raises(KeyError):
             _ = PytorchQuantumModel.from_checkpoint('model.lt')
         m.assert_called_with('model.lt', 'rb')
+
 
 def test_checkpoint_loading_file_not_found_errors():
     with patch('lambeq.training.checkpoint.open', mock_open(read_data='Not a valid checkpoint.')) as m, \
@@ -125,6 +132,7 @@ def test_pickling():
     assert diagram != pickled_diagram
     assert deepcopied_diagram != pickled_diagram
 
+
 def test_normalise():
     model = PytorchQuantumModel()
     input1 = np.linspace(-10, 10, 21)
@@ -134,6 +142,7 @@ def test_normalise():
     assert abs(normalised1.sum() - 1.0) < 1e-8
     assert abs(normalised2 - 0.5) < 1e-8
     assert np.all(normalised1 >= 0)
+
 
 def test_fast_subs_error():
     with pytest.raises(KeyError):


### PR DESCRIPTION
Fixes #225.