### PR TITLE
Simplify device logic in BobcatParser

### DIFF
--- a/lambeq/text2diagram/bobcat_parser.py
+++ b/lambeq/text2diagram/bobcat_parser.py
@@ -65,7 +65,7 @@ class BobcatParser(CCGParser):
     def __init__(self,
                  model_name_or_path: str = 'bert',
                  root_cats: Iterable[str] | None = None,
-                 device: int = -1,
+                 device: int | str | torch.device = 'cpu',
                  cache_dir: StrPathT | None = None,
                  force_download: bool = False,
                  verbose: str = VerbosityLevel.PROGRESS.value,
@@ -83,9 +83,13 @@ class BobcatParser(CCGParser):
         root_cats : iterable of str, optional
             A list of the categories allowed at the root of the parse
             tree.
-        device : int, default: -1
-            The GPU device ID on which to run the model, if positive.
-            If negative (the default), run on the CPU.
+        device : int, str, or torch.device
+            Specifies the device on which to run the tagger model.
+            - For CPU, use `'cpu'` or `-1`.
+            - For CUDA devices, use `'cuda:<device_id>'` or `<device_id>`.
+            - For Apple Silicon (MPS), use `'mps'`.
+            - You may also pass a :py:class:`torch.device` object.
+            - For other devices, refer to the PyTorch documentation.
         cache_dir : str or os.PathLike, optional
             The directory to which a downloaded pre-trained model should
             be cached instead of the standard cache
@@ -190,10 +194,9 @@ class BobcatParser(CCGParser):
             raise TypeError('BobcatParser got unexpected keyword argument(s): '
                             f'{", ".join(map(repr, kwargs))}')
 
-        device_ = torch.device('cpu' if device < 0 else f'cuda:{device}')
         model = (BertForChartClassification.from_pretrained(model_dir)
                                            .eval()
-                                           .to(device_))
+                                           .to(device))
         tokenizer = AutoTokenizer.from_pretrained(model_dir)
         self.tagger = Tagger(model, tokenizer, **config['tagger'])
 


### PR DESCRIPTION
Currently, the `device` parameter in `BobcatParser` only accepts `int` values, with custom logic to convert them into `torch.device` objects.

However, this approach limits support to just CPU and CUDA devices, and prevents users from specifying other valid devices like `'mps'`.

It would be better to delegate device handling to PyTorch itself, which already supports a wider range of devices natively.