### PR TITLE
Fix bug with untokenised input sentences for `OncillaParser`

### DIFF
--- a/lambeq/text2diagram/model_based_reader/oncilla_parser.py
+++ b/lambeq/text2diagram/model_based_reader/oncilla_parser.py
@@ -175,6 +175,11 @@ class OncillaParser(ModelBasedReader):
 
                 pregroup_tree: PregroupTreeNode | None = None
                 try:
+                    if sent[-1] == '.':
+                        # Remove ending '.' as this was removed from
+                        # the training dataset for training.
+                        sent = sent[:-1]
+
                     # Predict types and parents
                     parse_output = self.model._sentence2pred(sent,
                                                              self.tokenizer)

--- a/lambeq/text2diagram/model_based_reader/oncilla_parser.py
+++ b/lambeq/text2diagram/model_based_reader/oncilla_parser.py
@@ -307,8 +307,8 @@ class OncillaParser(ModelBasedReader):
             verbose = self.verbose
         if verbose is VerbosityLevel.TEXT.value:
             print('Turning pregroup trees to diagrams.', file=sys.stderr)
-        for tree, sentence in tqdm(
-            zip(pregroup_trees, sentences),
+        for tree in tqdm(
+            pregroup_trees,
             desc='Turning pregroup trees to diagrams',
             leave=False,
             total=len(pregroup_trees),
@@ -318,10 +318,11 @@ class OncillaParser(ModelBasedReader):
 
             if tree is not None:
                 try:
-                    diagram = tree.to_diagram(tokens=sentence)
+                    tokens = tree.get_words()
+                    diagram = tree.to_diagram(tokens=tokens)
                 except Exception as e:
                     if not suppress_exceptions:
-                        raise OncillaParseError(' '.join(sentence)) from e
+                        raise OncillaParseError(' '.join(tokens)) from e
 
             diagrams.append(diagram)
 

--- a/tests/test_discocirc_reader.py
+++ b/tests/test_discocirc_reader.py
@@ -55,7 +55,7 @@ class MockCorefResolver(CoreferenceResolver):
     'tree, diag_f, diag_s',
     zip(trees, frame_diags, sandwich_diags)
 )
-def test_discocirc_reader_w_ccgparser(monkeypatch, tree, diag_f, diag_s):
+def test_discocirc_reader_w_bobcatparser(tree, diag_f, diag_s):
     parser = MockBobcatParser()
     r = DisCoCircReader(parser=parser,
                         coref_resolver=MockCorefResolver())

--- a/tests/text2diagram/model_based_reader/test_bobcat_parser.py
+++ b/tests/text2diagram/model_based_reader/test_bobcat_parser.py
@@ -33,14 +33,25 @@ def simple_diagram():
 
 
 @pytest.fixture
+def simple_diagram_w_fullstop():
+    n, s = map(Ty, 'ns')
+    return Diagram.create_pregroup_diagram(
+        words=[Word('Alice', n), Word('likes', n.r @ s @ n.l), Word('Bob.', n)],
+        morphisms=[(Cup, 3, 4),(Cup, 0, 1)]
+    )
+
+
+@pytest.fixture
 def tokenised_empty_sentence():
     return []
 
 
-def test_sentence2diagram(bobcat_parser, sentence, simple_diagram):
+def test_sentence2diagram(bobcat_parser, sentence, simple_diagram, simple_diagram_w_fullstop):
     assert bobcat_parser.sentence2diagram(sentence) is not None
 
     assert bobcat_parser.sentence2diagram('Alice likes Bob') == simple_diagram
+    assert bobcat_parser.sentence2diagram('Alice likes Bob .') == simple_diagram
+    assert bobcat_parser.sentence2diagram('Alice likes Bob.') == simple_diagram_w_fullstop
 
 
 def test_sentence2tree(bobcat_parser, sentence):
@@ -86,26 +97,40 @@ def test_sentence2tree_tokenised(bobcat_parser, tokenised_sentence):
     assert bobcat_parser.sentence2tree(tokenised_sentence, tokenised=True) is not None
 
 
-def test_sentences2diagrams(bobcat_parser, sentence, simple_diagram):
+def test_sentences2diagrams(bobcat_parser, sentence, simple_diagram, simple_diagram_w_fullstop):
     assert bobcat_parser.sentences2diagrams([sentence]) is not None
 
     assert bobcat_parser.sentences2diagrams(['Alice likes Bob']) == [simple_diagram]
+    assert bobcat_parser.sentences2diagrams(['Alice likes Bob .']) == [simple_diagram]
+    assert bobcat_parser.sentences2diagrams(['Alice likes Bob.']) == [simple_diagram_w_fullstop]
 
 
-def test_sentence2diagram_tokenised(bobcat_parser, tokenised_sentence, simple_diagram):
+def test_sentence2diagram_tokenised(bobcat_parser, tokenised_sentence, simple_diagram, simple_diagram_w_fullstop):
     assert bobcat_parser.sentence2diagram(tokenised_sentence, tokenised=True) is not None
 
     assert bobcat_parser.sentence2diagram(
         'Alice likes Bob'.split(), tokenised=True
     ) == simple_diagram
+    assert bobcat_parser.sentence2diagram(
+        'Alice likes Bob .'.split(), tokenised=True
+    ) == simple_diagram
+    assert bobcat_parser.sentence2diagram(
+        'Alice likes Bob.'.split(), tokenised=True
+    ) == simple_diagram_w_fullstop
 
 
-def test_sentences2diagrams_tokenised(bobcat_parser, tokenised_sentence, simple_diagram):
+def test_sentences2diagrams_tokenised(bobcat_parser, tokenised_sentence, simple_diagram, simple_diagram_w_fullstop):
     assert bobcat_parser.sentences2diagrams([tokenised_sentence], tokenised=True) is not None
 
     assert bobcat_parser.sentences2diagrams(
         ['Alice likes Bob'.split()], tokenised=True
     ) == [simple_diagram]
+    assert bobcat_parser.sentences2diagrams(
+        ['Alice likes Bob .'.split()], tokenised=True
+    ) == [simple_diagram]
+    assert bobcat_parser.sentences2diagrams(
+        ['Alice likes Bob.'.split()], tokenised=True
+    ) == [simple_diagram_w_fullstop]
 
 
 def test_tokenised_type_check_untokenised_sentence(bobcat_parser, sentence):

--- a/tests/text2diagram/model_based_reader/test_bobcat_parser.py
+++ b/tests/text2diagram/model_based_reader/test_bobcat_parser.py
@@ -4,27 +4,43 @@ from io import StringIO
 from unittest.mock import patch
 
 from lambeq import BobcatParseError, BobcatParser, CCGType, VerbosityLevel
+from lambeq.backend.grammar import Cup, Diagram, Ty, Word
 
 
 @pytest.fixture(scope='module')
 def bobcat_parser():
     return BobcatParser(verbose=VerbosityLevel.SUPPRESS.value)
 
+
 @pytest.fixture
 def sentence():
     return 'What Alice is and is not .'
 
+
 @pytest.fixture
 def tokenised_sentence():
     return ['What', 'Alice', 'is', 'and', 'is', 'not', '.']
+
+
+
+@pytest.fixture
+def simple_diagram():
+    n, s = map(Ty, 'ns')
+    return Diagram.create_pregroup_diagram(
+        words=[Word('Alice', n), Word('likes', n.r @ s @ n.l), Word('Bob', n)],
+        morphisms=[(Cup, 3, 4),(Cup, 0, 1)]
+    )
+
 
 @pytest.fixture
 def tokenised_empty_sentence():
     return []
 
 
-def test_sentence2diagram(bobcat_parser, sentence):
+def test_sentence2diagram(bobcat_parser, sentence, simple_diagram):
     assert bobcat_parser.sentence2diagram(sentence) is not None
+
+    assert bobcat_parser.sentence2diagram('Alice likes Bob') == simple_diagram
 
 
 def test_sentence2tree(bobcat_parser, sentence):
@@ -70,17 +86,26 @@ def test_sentence2tree_tokenised(bobcat_parser, tokenised_sentence):
     assert bobcat_parser.sentence2tree(tokenised_sentence, tokenised=True) is not None
 
 
-def test_sentences2diagrams(bobcat_parser, sentence):
+def test_sentences2diagrams(bobcat_parser, sentence, simple_diagram):
     assert bobcat_parser.sentences2diagrams([sentence]) is not None
 
+    assert bobcat_parser.sentences2diagrams(['Alice likes Bob']) == [simple_diagram]
 
-def test_sentence2diagram_tokenised(bobcat_parser, tokenised_sentence):
+
+def test_sentence2diagram_tokenised(bobcat_parser, tokenised_sentence, simple_diagram):
     assert bobcat_parser.sentence2diagram(tokenised_sentence, tokenised=True) is not None
 
+    assert bobcat_parser.sentence2diagram(
+        'Alice likes Bob'.split(), tokenised=True
+    ) == simple_diagram
 
-def test_sentences2diagrams_tokenised(bobcat_parser, tokenised_sentence):
-    tokenised_sentence = ['What', 'Alice', 'is', 'and', 'is', 'not', '.']
+
+def test_sentences2diagrams_tokenised(bobcat_parser, tokenised_sentence, simple_diagram):
     assert bobcat_parser.sentences2diagrams([tokenised_sentence], tokenised=True) is not None
+
+    assert bobcat_parser.sentences2diagrams(
+        ['Alice likes Bob'.split()], tokenised=True
+    ) == [simple_diagram]
 
 
 def test_tokenised_type_check_untokenised_sentence(bobcat_parser, sentence):

--- a/tests/text2diagram/model_based_reader/test_oncilla_parser.py
+++ b/tests/text2diagram/model_based_reader/test_oncilla_parser.py
@@ -34,14 +34,25 @@ def simple_diagram():
 
 
 @pytest.fixture
+def simple_diagram_w_fullstop():
+    n, s = map(Ty, 'ns')
+    return Diagram.create_pregroup_diagram(
+        words=[Word('Alice', n), Word('likes', n.r @ s @ n.l), Word('Bob.', n)],
+        morphisms=[(Cup, 0, 1), (Cup, 3, 4)]
+    )
+
+
+@pytest.fixture
 def tokenised_empty_sentence():
     return []
 
 
-def test_sentence2diagram(oncilla_parser, sentence, simple_diagram):
+def test_sentence2diagram(oncilla_parser, sentence, simple_diagram, simple_diagram_w_fullstop):
     assert oncilla_parser.sentence2diagram(sentence) is not None
 
     assert oncilla_parser.sentence2diagram('Alice likes Bob') == simple_diagram
+    assert oncilla_parser.sentence2diagram('Alice likes Bob .') == simple_diagram
+    assert oncilla_parser.sentence2diagram('Alice likes Bob.') == simple_diagram_w_fullstop
 
 
 def test_empty_sentences(oncilla_parser):
@@ -113,26 +124,40 @@ def test_to_diagram_fail(oncilla_parser, monkeypatch):
     assert oncilla_parser.sentence2diagram('a', suppress_exceptions=True) is None
 
 
-def test_sentences2diagrams(oncilla_parser, sentence, simple_diagram):
+def test_sentences2diagrams(oncilla_parser, sentence, simple_diagram, simple_diagram_w_fullstop):
     assert oncilla_parser.sentences2diagrams([sentence]) is not None
 
     assert oncilla_parser.sentences2diagrams(['Alice likes Bob']) == [simple_diagram]
+    assert oncilla_parser.sentences2diagrams(['Alice likes Bob .']) == [simple_diagram]
+    assert oncilla_parser.sentences2diagrams(['Alice likes Bob.']) == [simple_diagram_w_fullstop]
 
 
-def test_sentence2diagram_tokenised(oncilla_parser, tokenised_sentence, simple_diagram):
+def test_sentence2diagram_tokenised(oncilla_parser, tokenised_sentence, simple_diagram, simple_diagram_w_fullstop):
     assert oncilla_parser.sentence2diagram(tokenised_sentence, tokenised=True) is not None
 
     assert oncilla_parser.sentence2diagram(
         'Alice likes Bob'.split(), tokenised=True
     ) == simple_diagram
+    assert oncilla_parser.sentence2diagram(
+        'Alice likes Bob .'.split(), tokenised=True
+    ) == simple_diagram
+    assert oncilla_parser.sentence2diagram(
+        'Alice likes Bob.'.split(), tokenised=True
+    ) == simple_diagram_w_fullstop
 
 
-def test_sentences2diagrams_tokenised(oncilla_parser, tokenised_sentence, simple_diagram):
+def test_sentences2diagrams_tokenised(oncilla_parser, tokenised_sentence, simple_diagram, simple_diagram_w_fullstop):
     assert oncilla_parser.sentences2diagrams([tokenised_sentence], tokenised=True) is not None
 
     assert oncilla_parser.sentences2diagrams(
         ['Alice likes Bob'.split()], tokenised=True
     ) == [simple_diagram]
+    assert oncilla_parser.sentences2diagrams(
+        ['Alice likes Bob .'.split()], tokenised=True
+    ) == [simple_diagram]
+    assert oncilla_parser.sentences2diagrams(
+        ['Alice likes Bob.'.split()], tokenised=True
+    ) == [simple_diagram_w_fullstop]
 
 
 def test_tokenised_type_check_untokenised_sentence(oncilla_parser, sentence):


### PR DESCRIPTION
This fixes the issue with the output for untokenised sentences. Also, a preprocessing step that removes the trailing `'.'` from sentences before getting model predictions is added.