### PR TITLE
Add Oncilla to CLI

### DIFF
--- a/lambeq/cli.py
+++ b/lambeq/cli.py
@@ -442,7 +442,6 @@ class ParserModule(CLIModule):
                             root_cats=cl_args.root_categories)
 
         if cl_args.mode == 'ccg':
-            # assert isinstance(parser, CCGParser)
             trees = parser.sentences2trees(sentences,
                                            tokenised=cl_args.tokenise)
             return [t.without_trivial_unary_rules() for t in trees
@@ -605,13 +604,6 @@ class DiagramSaveModule(CLIModule):
 def main() -> None:
     parser = prepare_parser()
     cl_args = parser.parse_args()
-    all_modules = [FileReaderModule(),
-                   ParserModule(),
-                   RewriterModule(),
-                   AnsatzModule(),
-                   (DiagramSaveModule()
-                    if cl_args.mode in ['string-diagram', 'pregroups']
-                    else CCGTreeSaveModule())]
     if cl_args.load_args is not None:
         saved_args = yaml.load(open(cl_args.load_args, 'r'),
                                Loader=yaml.FullLoader)
@@ -627,6 +619,14 @@ def main() -> None:
             cl_args.store_args = None
             yaml.dump(vars(cl_args), f, default_flow_style=False)
     data = None
+
+    all_modules = [FileReaderModule(),
+                   ParserModule(),
+                   RewriterModule(),
+                   AnsatzModule(),
+                   (DiagramSaveModule()
+                    if cl_args.mode in ['string-diagram', 'pregroups']
+                    else CCGTreeSaveModule())]
     for module in all_modules:
         data = module(cl_args, data)
 

--- a/lambeq/cli.py
+++ b/lambeq/cli.py
@@ -49,29 +49,37 @@ from lambeq.text2diagram.tree_reader import TreeReader
 from lambeq.tokeniser import SpacyTokeniser
 from lambeq.version import version
 
+
 AVAILABLE_PARSERS: dict[str, type] = {
-        'bobcat': BobcatParser,
-        'oncilla': OncillaParser,
+    'bobcat': BobcatParser,
+    'oncilla': OncillaParser,
 }
 
 AVAILABLE_READERS: dict[str, Reader | type[Reader]] = {
-        'spiders': spiders_reader,
-        'stairs': stairs_reader,
-        'cups': cups_reader,
-        'tree': TreeReader}
+    'spiders': spiders_reader,
+    'stairs': stairs_reader,
+    'cups': cups_reader,
+    'tree': TreeReader
+}
 
-AVAILABLE_ANSATZE: dict[str, type[BaseAnsatz]] = {'iqp': IQPAnsatz,
-                                                  'tensor': TensorAnsatz,
-                                                  'spider': SpiderAnsatz,
-                                                  'mps': MPSAnsatz}
+AVAILABLE_ANSATZE: dict[str, type[BaseAnsatz]] = {
+    'iqp': IQPAnsatz,
+    'tensor': TensorAnsatz,
+    'spider': SpiderAnsatz,
+    'mps': MPSAnsatz
+}
 
-AVAILABLE_IMAGE_TYPES: list[str] = ['png', 'pdf', 'jpeg', 'jpg', 'eps',
-                                    'pgf', 'ps', 'raw', 'rgba', 'svg',
-                                    'svgz', 'tif', 'tiff']
+AVAILABLE_IMAGE_TYPES: list[str] = [
+    'png', 'pdf', 'jpeg', 'jpg', 'eps',
+    'pgf', 'ps', 'raw', 'rgba', 'svg',
+    'svgz', 'tif', 'tiff'
+]
 
-DEFAULT_ARG_VALUES: dict[str, str] = {'output_format': 'text-unicode',
-                                      'image_format': 'png',
-                                      'mode': 'string-diagram'}
+DEFAULT_ARG_VALUES: dict[str, str] = {
+    'output_format': 'text-unicode',
+    'image_format': 'png',
+    'mode': 'string-diagram'
+}
 
 
 class ArgumentList:
@@ -364,7 +372,7 @@ def validate_args(cl_args: argparse.Namespace) -> None:
                              'currently not supported. Try text forms, `json` '
                              'or `pickle`.')
         if cl_args.parser is not None and cl_args.parser != 'bobcat':
-            raise ValueError('A CCG parser is needed for CGG mode.')
+            raise ValueError('A CCG parser is needed for CCG mode.')
     if cl_args.output_format in ['text-ascii', 'text-unicode', 'json']:
         if cl_args.mode in ['string-diagram', 'pregroups']:
             if cl_args.ansatz is not None:
@@ -438,7 +446,8 @@ class ParserModule(CLIModule):
             parser = AVAILABLE_PARSERS[cl_args.parser]()
         else:
             parser = AVAILABLE_PARSERS['bobcat'](
-                            root_cats=cl_args.root_categories)
+                root_cats=cl_args.root_categories
+            )
 
         if cl_args.mode == 'ccg':
             trees = parser.sentences2trees(sentences,

--- a/lambeq/cli.py
+++ b/lambeq/cli.py
@@ -39,7 +39,6 @@ from lambeq.ansatz.tensor import MPSAnsatz, SpiderAnsatz, TensorAnsatz
 from lambeq.backend import grammar, tensor
 from lambeq.rewrite import RemoveSwapsRewriter
 from lambeq.text2diagram.base import Reader
-from lambeq.text2diagram.ccg_parser import CCGParser
 from lambeq.text2diagram.ccg_tree import CCGTree
 from lambeq.text2diagram.linear_reader import (cups_reader,
                                                stairs_reader)
@@ -364,7 +363,7 @@ def validate_args(cl_args: argparse.Namespace) -> None:
             raise ValueError('Generating binary images from CCG diagrams is '
                              'currently not supported. Try text forms, `json` '
                              'or `pickle`.')
-        if AVAILABLE_PARSERS[cl_args.parser] != CCGParser:
+        if cl_args.parser is not None and cl_args.parser != 'bobcat':
             raise ValueError('A CCG parser is needed for CGG mode.')
     if cl_args.output_format in ['text-ascii', 'text-unicode', 'json']:
         if cl_args.mode in ['string-diagram', 'pregroups']:

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,6 @@ classifiers =
 packages =
     lambeq
     lambeq.ansatz
-    lambeq.text2diagram
     lambeq.backend
     lambeq.backend.converters
     lambeq.backend.drawing
@@ -52,7 +51,10 @@ packages =
     lambeq.core
     lambeq.experimental
     lambeq.experimental.discocirc
+    lambeq.oncilla
     lambeq.rewrite
+    lambeq.text2diagram
+    lambeq.text2diagram.model_based_reader
     lambeq.tokeniser
     lambeq.training
 install_requires =
@@ -86,7 +88,7 @@ test =
     coverage[toml]
     pytest
 
-experimental = 
+experimental =
     numpy == 1.26.4
     spacy ~= 3.4.0
     spacy-experimental ~= 0.6.4


### PR DESCRIPTION
This PR adds Oncilla to CLI for easy access, and removes (from CLI) the deprecated DepCCG. It also registers properly the new oncilla-related packages.