### PR TITLE
Fix no-, multiple-root prediction for parent predictions

### DIFF
--- a/lambeq/oncilla/parser.py
+++ b/lambeq/oncilla/parser.py
@@ -37,6 +37,10 @@ from transformers.modeling_outputs import ModelOutput
 from transformers.models.bert.modeling_bert import BertEncoder
 
 from lambeq.core.utils import TokenisedSentenceType
+from lambeq.text2diagram.pregroup_tree_converter import (
+    has_multiple_roots_assigned,
+    root_not_assigned,
+)
 
 
 logging.basicConfig()
@@ -758,12 +762,17 @@ class BertForSentenceToTree(BertPreTrainedModel):
 
         type_logits = getattr(out, 'type_logits', out[0])
         parent_logits = getattr(out, 'parent_logits', out[1])
+        # print(f'{inputs_cpu["input_ids"] = }')
+        # print(f'{inputs_cpu["input_ids"].shape = }')
+        # print(f'{inputs_cpu["word_ids"] = }')
+        # print(f'{inputs.tokens(0) = }')
+        # print(f'{parent_logits.shape = }, {parent_logits = }')
         parent_preds = torch.argmax(parent_logits, 2).tolist()[0]
         type_preds = torch.argmax(type_logits, 2).tolist()[0]
         true_type_preds = []
         true_parent_preds = []
         current_wid = None
-        for wid, t, p in zip(inputs.word_ids(), type_preds, parent_preds):
+        for wid, t, p in zip(word_ids, type_preds, parent_preds):
             if wid is not None:
                 w = sentence_w_root[wid]
                 if w != ROOT_TOKEN and current_wid != wid:
@@ -776,4 +785,58 @@ class BertForSentenceToTree(BertPreTrainedModel):
                                for t in true_type_preds]
         true_parent_preds = [[p - 1] for p in true_parent_preds]
 
+        # print(f'orig parent_preds: {true_parent_preds}')
+        # Check if root is not assigned or has multiple roots
+        if (root_not_assigned(true_parent_preds)
+                or has_multiple_roots_assigned(true_parent_preds)):
+            true_parent_preds = self._get_parent_preds_with_forced_root(
+                parent_logits, word_ids,
+            )
+            # print(f'new parent_preds: {true_parent_preds}')
+
         return ParserOutput(sentence, true_type_preds_str, true_parent_preds)
+
+    def _get_parent_preds_with_forced_root(
+        self,
+        parent_logits: torch.Tensor,
+        word_ids: list[int | None],
+    ) -> list[list[int]]:
+        # print(f'{parent_logits.shape = }')
+        # print(f'{parent_logits = }')
+        # print(f'{word_ids = }')
+        root_logits = parent_logits.clone()[0, :, 0]
+        # print(f'{root_logits = }')
+
+        # Use `word_ids` to mask the root logits
+        curr_word_id = None
+        for i, word_id in enumerate(word_ids):
+            if word_id in {-1000, 0} or curr_word_id == word_id:
+                root_logits[i] = -torch.inf
+            curr_word_id = word_id
+
+        # Get root word
+        root_word_id = torch.argmax(root_logits).item()
+        # print(f'{root_word = }')
+
+        # Re-mask parent logits incorporating the root word index
+        parent_logits_clone = parent_logits.clone()
+        for i, _ in enumerate(word_ids):
+            parent_logits_clone[0, i, 0] = (torch.inf if i == root_word_id
+                                            else -torch.inf)
+
+        # print(f'{parent_logits_clone = }')
+        parent_preds = torch.argmax(parent_logits_clone, 2).tolist()[0]
+        # print(f'temp parent_preds: {parent_preds}')
+
+        true_parent_preds = []
+        curr_word_id = None
+        for word_id, p in zip(word_ids, parent_preds):
+            if (word_id is not None
+                and (word_id not in {-1000, 0}
+                     and word_id != curr_word_id)):
+                curr_word_id = word_id
+                true_parent_preds.append(p)
+
+        true_parent_preds = [[p - 1] for p in true_parent_preds]
+
+        return true_parent_preds

--- a/lambeq/text2diagram/pregroup_tree_converter.py
+++ b/lambeq/text2diagram/pregroup_tree_converter.py
@@ -459,6 +459,14 @@ def has_self_as_parents(parents: list[list[int]]) -> bool:
     return any([i in parent for i, parent in enumerate(parents)])
 
 
+def has_multiple_roots_assigned(parents: list[list[int]]) -> bool:
+    return sum([pp == [ROOT_INDEX] for pp in parents]) > 1
+
+
+def root_not_assigned(parents: list[list[int]]) -> bool:
+    return [ROOT_INDEX] not in parents
+
+
 def str_to_type(type_str: str) -> Ty:
     """Convert the string representation of an atomic type
     to its `Ty` instance."""

--- a/tests/text2diagram/model_based_reader/test_oncilla_parser.py
+++ b/tests/text2diagram/model_based_reader/test_oncilla_parser.py
@@ -9,6 +9,8 @@ from lambeq.text2diagram import PregroupTreeNode
 from lambeq.text2diagram.model_based_reader import oncilla_parser as oncilla_parser_module
 
 
+n, s = map(Ty, 'ns')
+
 @pytest.fixture(scope='module')
 def oncilla_parser():
     return OncillaParser(verbose=VerbosityLevel.SUPPRESS.value)
@@ -26,7 +28,6 @@ def tokenised_sentence():
 
 @pytest.fixture
 def simple_diagram():
-    n, s = map(Ty, 'ns')
     return Diagram.create_pregroup_diagram(
         words=[Word('Alice', n), Word('likes', n.r @ s @ n.l), Word('Bob', n)],
         morphisms=[(Cup, 0, 1), (Cup, 3, 4)]
@@ -220,3 +221,25 @@ def test_tqdm_progress(oncilla_parser, sentence):
     with patch('sys.stderr', new=StringIO()) as fake_out:
         _ = oncilla_parser.sentences2diagrams([sentence], verbose=VerbosityLevel.PROGRESS.value)
         assert fake_out.getvalue().rstrip() != ''
+
+
+def test_empty_codomain(oncilla_parser):
+    diag = oncilla_parser.sentence2diagram('let me in now')
+
+    diag_expected = Diagram.create_pregroup_diagram(
+        words=[
+            Word('let', n.r @ s @ n.l),
+            Word('me', n),
+            Word('in', n.r @ s),
+            Word('now', s.r @ n.r.r @ s.r @ n.r.r @ n.r @ s),
+        ],
+        morphisms=[
+            (Cup, 5, 6),
+            (Cup, 2, 3),
+            (Cup, 4, 7),
+            (Cup, 1, 8),
+            (Cup, 0, 9),
+        ]
+    )
+
+    assert diag == diag_expected


### PR DESCRIPTION
Fixes #233

This is to address the cases where the initial parent prediction either
* Doesn't have a root word predicted
* Has multiple root words predicted

This enforces a greedy heuristic that first predicts a single root word for the entire sentence,
and then proceeds with predicting the parents for the rest of the words, applying masking first to prevent changing the original root word prediction.