### PR TITLE
Improve free symbols search for large tensors

### DIFF
--- a/lambeq/backend/drawing/drawing.py
+++ b/lambeq/backend/drawing/drawing.py
@@ -54,7 +54,6 @@ from lambeq.backend.drawing.tikz_backend import (
 )
 from lambeq.backend.grammar import Box, Diagram
 
-
 if TYPE_CHECKING:
     from IPython.core.display import HTML as HTML_ty
 

--- a/lambeq/backend/drawing/drawing.py
+++ b/lambeq/backend/drawing/drawing.py
@@ -134,7 +134,7 @@ def draw(diagram: Diagram, **params) -> None:
         backend: DrawingBackend = params.pop('backend')
     elif params.get('to_tikz', False):
         backend = TikzBackend(
-            use_tikzstyles=params.get('use_tikzstyles', None),
+            use_tikzstyles=params.get('use_tikzstyles', False),
             box_linewidth=params.get('box_linewidth', TIKZ_BOX_LINEWIDTH),
             wire_linewidth=params.get('wire_linewidth',
                                       TIKZ_WIRE_LINEWIDTH),
@@ -221,7 +221,7 @@ def draw_pregroup(diagram: Diagram, **params) -> None:
         backend: DrawingBackend = params.pop('backend')
     elif params.get('to_tikz', False):
         backend = TikzBackend(
-            use_tikzstyles=params.get('use_tikzstyles', None))
+            use_tikzstyles=params.get('use_tikzstyles', False))
     else:
         backend = MatBackend(figsize=params.get('figsize', None))
 
@@ -372,7 +372,7 @@ def draw_equation(*terms: grammar.Diagram,
         backend: DrawingBackend = params.pop('backend')
     elif params.get('to_tikz', False):
         backend = TikzBackend(
-            use_tikzstyles=params.get('use_tikzstyles', None))
+            use_tikzstyles=params.get('use_tikzstyles', False))
     else:
         backend = MatBackend(figsize=params.get('figsize', None))
 

--- a/lambeq/backend/grammar.py
+++ b/lambeq/backend/grammar.py
@@ -33,9 +33,9 @@ from typing_extensions import Self
 
 from lambeq.core.utils import fast_deepcopy
 
-
 if TYPE_CHECKING:
     import discopy
+
     from lambeq.text2diagram.pregroup_tree import PregroupTreeNode
 
 

--- a/lambeq/backend/pennylane.py
+++ b/lambeq/backend/pennylane.py
@@ -54,7 +54,6 @@ from lambeq.backend.quantum import (Gate, Measure,
                                     to_circuital)
 from lambeq.backend.symbol import lambdify, Symbol
 
-
 if TYPE_CHECKING:
     from lambeq.backend.quantum import Diagram
 

--- a/lambeq/backend/quantum.py
+++ b/lambeq/backend/quantum.py
@@ -1083,7 +1083,7 @@ class Scalar(Box):
         with backend() as np:
             return np.array(self.data)
 
-    __hash__: Callable[[Box], int] = Box.__hash__
+    __hash__: Callable[[Box], int] = Box.__hash__   # type: ignore[assignment]
 
     def dagger(self):
         return replace(self, data=self.data.conjugate())
@@ -1109,7 +1109,7 @@ class Sqrt(Scalar):
         with backend() as np:
             return np.array(self.data ** .5)
 
-    __hash__: Callable[[], int] = Scalar.__hash__
+    __hash__: Callable[[], int] = Scalar.__hash__   # type: ignore[assignment]
 
     def dagger(self):
         return replace(self, data=np.conjugate(self.data))
@@ -1150,8 +1150,8 @@ class Daggered(tensor.Daggered, Box):
     def dagger(self) -> Box:
         return self.box
 
-    __hash__: Callable[[Box], int] = Box.__hash__
-    __repr__: Callable[[Box], str] = Box.__repr__
+    __hash__: Callable[[Box], int] = Box.__hash__   # type: ignore[assignment]
+    __repr__: Callable[[Box], str] = Box.__repr__   # type: ignore[assignment]
 
 
 class Bit(Box):

--- a/lambeq/backend/tensor.py
+++ b/lambeq/backend/tensor.py
@@ -53,7 +53,7 @@ class Dim(grammar.Ty):
         Product of contained dimensions.
 
     """
-    objects: list[Self]  # type: ignore[assignment,misc]
+    objects: list[Self]  # type: ignore[misc]
 
     def __init__(self,
                  *dim: int,

--- a/lambeq/backend/tensor.py
+++ b/lambeq/backend/tensor.py
@@ -245,7 +245,8 @@ class Box(grammar.Box):
                 if (
                     not hasattr(data, 'shape') or data.shape != ()
                 ) and not (
-                    not isinstance(data, np.ndarray) or np.issubdtype(data.dtype, np.number)
+                    not isinstance(data, np.ndarray)
+                    or np.issubdtype(data.dtype, np.number)
                 ):
                     return set().union(*map(recursive_free_symbols, data))
             # Remove scale before adding to set

--- a/lambeq/backend/tensor.py
+++ b/lambeq/backend/tensor.py
@@ -244,8 +244,8 @@ class Box(grammar.Box):
             if isinstance(data, Iterable):
                 if (
                     not hasattr(data, 'shape') or data.shape != ()
-                ) and (
-                    not hasattr(data, 'dtype') or data.dtype != object
+                ) and not (
+                    not isinstance(data, np.ndarray) or np.issubdtype(data.dtype, np.number)
                 ):
                     return set().union(*map(recursive_free_symbols, data))
             # Remove scale before adding to set

--- a/lambeq/backend/tensor.py
+++ b/lambeq/backend/tensor.py
@@ -242,7 +242,11 @@ class Box(grammar.Box):
             if isinstance(data, Mapping):
                 data = data.values()
             if isinstance(data, Iterable):
-                if not hasattr(data, 'shape') or data.shape != ():
+                if (
+                    not hasattr(data, 'shape') or data.shape != ()
+                ) and (
+                    not hasattr(data, 'dtype') or data.dtype != object
+                ):
                     return set().union(*map(recursive_free_symbols, data))
             # Remove scale before adding to set
             return {data.unscaled} if isinstance(data, Symbol) else set()

--- a/lambeq/bobcat/lexicon.py
+++ b/lambeq/bobcat/lexicon.py
@@ -37,7 +37,7 @@ class Atom(FastIntEnum):
 
 for atom in Atom._member_map_.values():
     if TYPE_CHECKING:
-        from typing import cast
+        from typing import cast     # noqa: I300
         atom = cast(Atom, atom)
     atom.is_punct = atom >= Atom.COMMA
 

--- a/lambeq/core/utils.py
+++ b/lambeq/core/utils.py
@@ -21,7 +21,6 @@ from typing import Any, List, TYPE_CHECKING, Union
 
 import spacy
 
-
 if TYPE_CHECKING:
     import spacy.cli
 

--- a/lambeq/experimental/discocirc/coref_resolver.py
+++ b/lambeq/experimental/discocirc/coref_resolver.py
@@ -21,7 +21,6 @@ import torch
 
 from lambeq.core.utils import get_spacy_tokeniser
 
-
 if TYPE_CHECKING:
     import spacy.cli
 

--- a/lambeq/text2diagram/depccg_parser.py
+++ b/lambeq/text2diagram/depccg_parser.py
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
     from depccg.annotator import (annotate_XX, english_annotator,
                                   japanese_annotator)
     from depccg.cat import Category
+
     from lambeq.backend.grammar import Diagram
 
 
@@ -256,7 +257,7 @@ class DepCCGParser(CCGParser):
                                  '`sentences` does not have type '
                                  '`list[list[str]]`.')
             if TYPE_CHECKING:  # temporary fix
-                from typing import cast
+                from typing import cast     # noqa: I100
                 sentences = cast(list[list[str]], sentences)
         else:
             if not untokenised_batch_type_check(sentences):

--- a/lambeq/tokeniser/spacy_tokeniser.py
+++ b/lambeq/tokeniser/spacy_tokeniser.py
@@ -32,7 +32,6 @@ import spacy.lang.en
 from lambeq.core.utils import get_spacy_tokeniser
 from lambeq.tokeniser import Tokeniser
 
-
 if TYPE_CHECKING:
     import spacy.cli
 

--- a/lambeq/training/loss.py
+++ b/lambeq/training/loss.py
@@ -26,8 +26,9 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 if TYPE_CHECKING:
-    from jax import numpy as jnp
     from types import ModuleType
+
+    from jax import numpy as jnp
 
 
 class LossFunction(ABC):

--- a/lambeq/training/nelder_mead_optimizer.py
+++ b/lambeq/training/nelder_mead_optimizer.py
@@ -259,7 +259,7 @@ class NelderMeadOptimizer(Optimizer):
                 raise ValueError(
                     'Objective function must return a scalar'
                 ) from e
-        return result
+        return result   # type: ignore[return-value]
 
     def backward(self, batch: tuple[Iterable[Any], np.ndarray]) -> float:
         """Calculate the gradients of the loss function.

--- a/lambeq/training/numpy_model.py
+++ b/lambeq/training/numpy_model.py
@@ -37,7 +37,6 @@ from lambeq.backend.quantum import Diagram as Circuit
 from lambeq.backend.tensor import Diagram
 from lambeq.training.quantum_model import QuantumModel
 
-
 if TYPE_CHECKING:
     from jax import numpy as jnp
 


### PR DESCRIPTION
## Problem
`tensor.Box.free_symbols` very slow for large tensors. This is because a `isinstance` is called for each entry in the tensor.

## Solution
This PR optimise the `free_symbols` method such that numerical arrays are not recursively searched for symbols. 

```python
import time

from lambeq import Symbol
from lambeq.backend.tensor import Box, Dim
import numpy as np

sym = Symbol('x')

d = 1000
box_with_sym = Box('box_sym', Dim(d), Dim(d))
box_without_sym = Box('box_no_sym', Dim(d), Dim(d))

box_with_sym.data = np.random.rand(d, d).astype(object)
box_without_sym.data = np.random.rand(d, d)
box_with_sym.data[0, 0] = sym

start = time.time()
symbols = box_with_sym.free_symbols
end = time.time()
print(f"Time taken: {end - start:.6f} seconds")

start = time.time()
symbols = box_without_sym.free_symbols
end = time.time()
print(f"Time taken: {end - start:.6f} seconds")
```

### without this PR
```
(With symbol) Time taken: 0.563968 seconds
(Without symbol) Time taken: 0.555081 seconds
```

### with this PR
```
(With symbol) Time taken: 0.559249 seconds
(Without symbol) Time taken: 0.000064 seconds
```