### PR TITLE
Fix file path creation for `CachedTnPathOptimizer`

### DIFF
--- a/lambeq/training/tn_path_optimizer.py
+++ b/lambeq/training/tn_path_optimizer.py
@@ -194,7 +194,7 @@ class CachedTnPathOptimizer(TnPathOptimizer):
                     self.cached_paths = pickle.load(f)
             except FileNotFoundError:
                 # Make sure the path exists for future use.
-                self.filepath.mkdir(parents=True, exist_ok=True)
+                self.filepath.parent.mkdir(parents=True, exist_ok=True)
             except EOFError:
                 # No previous paths present; continue.
                 pass


### PR DESCRIPTION
previously the code created the desired filepath as a directory, which then failed later.