### PR TITLE
feat(drawing/text): implement ASCII rendering for arbitrary diagrams

### DIFF
--- a/ASCII_DRAWING_IMPLEMENTATION.md
+++ b/ASCII_DRAWING_IMPLEMENTATION.md
@@ -1,0 +1,91 @@
+# ASCII Drawing Implementation for All Lambeq Diagrams
+
+## Summary
+
+Successfully implemented ASCII drawing functionality for all lambeq diagram types (grammar, tensor, and quantum), extending beyond the previous limitation of only supporting pregroup diagrams.
+
+## Changes Made
+
+### 1. Extended `DiagramTextPrinter` Class
+- Implemented the `diagram2str` method in the base `DiagramTextPrinter` class
+- Added logic to detect pregroup diagrams and delegate to the specialized printer
+- Created `_render_general_diagram` method for handling arbitrary diagrams
+- Implemented `_render_layer` method for processing individual diagram layers
+- Added `_get_box_text` method for generating text representations of different box types
+
+### 2. Updated Drawing Module
+- Modified `render_as_str` function in `drawing.py` to use the general `DiagramTextPrinter`
+- Removed the `NotImplementedError` for non-pregroup diagrams
+
+### 3. Box Type Support
+The implementation now supports rendering of:
+- **Word** boxes: Display the word name
+- **Cup** boxes: Unicode `╰─╯` or ASCII `\_/`
+- **Cap** boxes: Unicode `╭─╮` or ASCII `/‾\`
+- **Swap** boxes: Display as `X`
+- **Spider** boxes: Show as `Spider[n→m]` with input/output counts
+- **Daggered** boxes: Display with `†` symbol
+- **Frame** boxes: Show as `[name]`
+- **Generic** boxes: Display name or show transformation `dom→cod`
+
+### 4. Features
+- **Box width calculation**: Automatically adjusts box width to fit text content
+- **Wire tracking**: Maintains wire positions throughout the diagram
+- **Type display**: Shows input and output types with configurable separators
+- **ASCII mode**: Supports both Unicode and ASCII-only rendering
+- **Configurable spacing**: Adjustable word spacing between boxes
+- **Type separator**: Option to use `@` or `·` for type composition
+
+### 5. Test Coverage
+Created comprehensive unit tests in `tests/backend/test_text_printer_general.py` covering:
+- Empty diagrams
+- Simple and composite diagrams
+- Parallel composition
+- All special box types (Spider, Cap, Cup, Swap, Daggered, Frame)
+- Tensor and quantum diagrams
+- ASCII vs Unicode modes
+- Configuration options
+- Edge cases (no domain/codomain boxes)
+
+## Usage Examples
+
+```python
+from lambeq.backend.grammar import Box, Ty, Word, Cup, Id
+
+# Simple grammar diagram
+n = Ty('n')
+s = Ty('s')
+diagram = Word("Alice", n) @ Word("runs", n.r @ s) >> Cup(n, n.r) @ Id(s)
+print(diagram.render_as_str())
+
+# Output:
+# Alice   runs
+# ─────  ─────
+#   n    n.r·s
+#   ╰─────╯  │
+
+# Non-pregroup diagram with generic boxes
+f = Box('process', n, s)
+g = Box('analyze', s, n)
+diagram = f >> g
+print(diagram.render_as_str())
+
+# Tensor diagram
+from lambeq.backend.tensor import Box as TensorBox, Dim
+A = TensorBox("A", Dim(2), Dim(3))
+B = TensorBox("B", Dim(3), Dim(4))
+diagram = A >> B
+print(diagram.render_as_str())
+
+# Quantum circuit
+from lambeq.backend.quantum import H, CX, qubit
+diagram = H @ qubit >> CX
+print(diagram.render_as_str())
+```
+
+## Testing
+All tests pass successfully:
+- 20/20 tests pass in `test_text_printer_general.py`
+- 8/8 tests pass in existing `test_text_printer.py`
+
+The implementation maintains backward compatibility with existing pregroup diagram rendering while adding support for all other diagram types in lambeq.

--- a/lambeq/backend/drawing/drawing.py
+++ b/lambeq/backend/drawing/drawing.py
@@ -47,7 +47,7 @@ from lambeq.backend.drawing.mat_backend import (
     BOX_LINEWIDTH as MAT_BOX_LINEWIDTH, MatBackend,
     WIRE_LINEWIDTH as MAT_WIRE_LINEWIDTH
 )
-from lambeq.backend.drawing.text_printer import PregroupTextPrinter
+from lambeq.backend.drawing.text_printer import DiagramTextPrinter, PregroupTextPrinter
 from lambeq.backend.drawing.tikz_backend import (
     BOX_LINEWIDTH as TIKZ_BOX_LINEWIDTH, TikzBackend,
     WIRE_LINEWIDTH as TIKZ_WIRE_LINEWIDTH
@@ -273,17 +273,11 @@ def render_as_str(diagram: Diagram,
 
     """
 
-    if diagram.is_pregroup:
-        text_printer = PregroupTextPrinter(word_spacing,
-                                           use_at_separator,
-                                           compress_layers,
-                                           use_ascii)
-    else:
-        # TODO: Add text/CLI drawing for non-pregroup diagrams.
-        raise NotImplementedError('Text drawing is only supported for'
-                                  ' pregroups. Provided diagram is not a'
-                                  ' pregroup diagram.')
-
+    # Use the general DiagramTextPrinter which handles both pregroup and non-pregroup diagrams
+    text_printer = DiagramTextPrinter(word_spacing,
+                                      use_at_separator,
+                                      compress_layers,
+                                      use_ascii)
     return text_printer.diagram2str(diagram)
 
 

--- a/lambeq/backend/drawing/text_printer.py
+++ b/lambeq/backend/drawing/text_printer.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 from dataclasses import dataclass, InitVar
 from enum import Enum
 
-from lambeq.backend.grammar import Cup, Diagram, Word
+from lambeq.backend.grammar import Cup, Diagram, Word, Swap, Spider, Box, Cap, Daggered, Frame
 
 
 class _MorphismType(Enum):
@@ -94,8 +94,260 @@ class DiagramTextPrinter:
         self.chr_set = (UNICODE_CHAR_SET if not use_ascii else ASCII_CHAR_SET)
 
     def diagram2str(self, diagram: Diagram) -> str:
-        # TODO: Add text/CLI drawing for non-pregroup diagrams.
-        raise NotImplementedError()
+        """Produces a string that contains a graphical representation of
+        the input diagram using text characters.
+
+        Parameters
+        ----------
+        diagram: :py:class:`lambeq.backend.grammar.Diagram`
+            The diagram to be printed.
+
+        Returns
+        -------
+        str
+            String that contains the graphical representation of the
+            diagram.
+        """
+        if not isinstance(diagram, Diagram):
+            raise ValueError('The input is not a valid diagram.')
+        
+        if diagram.is_pregroup:
+            # If it's a pregroup diagram, use the specialized printer
+            printer = PregroupTextPrinter(self.word_spacing, 
+                                         self.use_at_separator, 
+                                         self.compress_layers, 
+                                         use_ascii=(self.chr_set == ASCII_CHAR_SET))
+            return printer.diagram2str(diagram)
+        
+        # For non-pregroup diagrams, use general rendering
+        return self._render_general_diagram(diagram)
+    
+    def _render_general_diagram(self, diagram: Diagram) -> str:
+        """Render a general (non-pregroup) diagram."""
+        if not diagram.layers:
+            return ""
+        
+        # Track wire positions throughout the diagram
+        # wire_positions maps wire indices to column positions
+        wire_positions = {}
+        
+        # Calculate initial positions for input wires
+        type_sep = ' @ ' if self.use_at_separator else self.chr_set['DOT']
+        input_types = [str(t) for t in diagram.dom]
+        
+        # Handle empty domain
+        if not input_types:
+            current_x = 0
+        else:
+            # Position input wires with spacing
+            current_x = 0
+            for i, typ in enumerate(input_types):
+                wire_positions[i] = current_x + len(typ) // 2
+                current_x += len(typ) + len(type_sep)
+        
+        # Lists to store all lines to be printed
+        lines = []
+        
+        # Add input types line if there are inputs
+        if input_types:
+            input_line = type_sep.join(input_types)
+            lines.append(input_line)
+        
+        # Track active wires: maps wire index to its type
+        active_wires = {i: diagram.dom[i] for i in range(len(diagram.dom))}
+        next_wire_idx = len(diagram.dom)
+        
+        # Process each layer
+        for layer_idx, layer in enumerate(diagram.layers):
+            # Render this layer
+            layer_lines, wire_positions, active_wires, next_wire_idx = \
+                self._render_layer(layer, wire_positions, active_wires, 
+                                 next_wire_idx, layer_idx == 0)
+            lines.extend(layer_lines)
+        
+        # Add output types line if there are outputs
+        if diagram.cod:
+            # Draw final connecting wires
+            output_indices = list(sorted(active_wires.keys()))[:len(diagram.cod)]
+            if output_indices:
+                max_pos = max(wire_positions[idx] for idx in output_indices)
+                wire_line = ''
+                for idx in output_indices:
+                    pos = wire_positions[idx]
+                    wire_line = wire_line.ljust(pos) + self.chr_set['BAR']
+                lines.append(wire_line)
+            
+            # Draw output types
+            output_line = ''
+            for i, idx in enumerate(output_indices):
+                if i > 0:
+                    output_line += type_sep
+                output_line = output_line.ljust(wire_positions[idx] - len(str(diagram.cod[i]))//2)
+                output_line += str(diagram.cod[i])
+            lines.append(output_line)
+        
+        return '\n'.join(lines)
+    
+    def _render_layer(self, layer, wire_positions, active_wires, next_wire_idx, is_first_layer):
+        """Render a single layer of the diagram."""
+        lines = []
+        
+        # Get box and offsets
+        box = layer.box
+        left_wires = layer.left
+        right_wires = layer.right
+        
+        # Calculate box offset (number of wires to the left)
+        offset = len(left_wires)
+        
+        # Get box text representation
+        box_text = self._get_box_text(box)
+        box_width = len(box_text)
+        
+        # Get input wire indices for this box
+        input_indices = list(sorted(active_wires.keys()))[offset:offset + len(box.dom)]
+        
+        # Calculate box position
+        if input_indices:
+            # Position box centered over its input wires
+            leftmost = min(wire_positions[idx] for idx in input_indices)
+            rightmost = max(wire_positions[idx] for idx in input_indices)
+            box_center = (leftmost + rightmost) // 2
+        else:
+            # No input wires - position after existing wires
+            if wire_positions:
+                box_center = max(wire_positions.values()) + self.word_spacing + box_width // 2
+            else:
+                box_center = box_width // 2
+        
+        box_left = box_center - box_width // 2
+        
+        # Ensure box doesn't overlap with existing content
+        if wire_positions:
+            min_left = max(wire_positions.values()) + self.word_spacing
+            if box_left < min_left:
+                shift = min_left - box_left
+                box_left += shift
+                box_center += shift
+        
+        # Draw input wires to box (if not first layer)
+        if not is_first_layer and input_indices:
+            max_pos = max(wire_positions.values()) if wire_positions else 0
+            wire_line = ''
+            
+            # Draw vertical wires
+            all_positions = set()
+            for idx in sorted(active_wires.keys()):
+                pos = wire_positions[idx]
+                all_positions.add(pos)
+                if idx in input_indices:
+                    # This wire connects to the box
+                    wire_line = wire_line.ljust(pos) + self.chr_set['BAR']
+                else:
+                    # This wire passes through
+                    wire_line = wire_line.ljust(pos) + self.chr_set['BAR']
+            
+            if wire_line.strip():
+                lines.append(wire_line)
+        
+        # Draw the box
+        box_line = ' ' * box_left + box_text
+        lines.append(box_line)
+        
+        # Update wire positions and active wires
+        new_wire_positions = {}
+        new_active_wires = {}
+        
+        # First, handle wires that don't connect to this box
+        for idx in sorted(active_wires.keys()):
+            if idx < offset or idx >= offset + len(box.dom):
+                # Wire passes through unchanged
+                new_wire_positions[idx] = wire_positions[idx]
+                new_active_wires[idx] = active_wires[idx]
+        
+        # Then, add output wires from the box
+        if box.cod:
+            # Position output wires evenly under the box
+            cod_spacing = box_width / (len(box.cod) + 1)
+            for i, typ in enumerate(box.cod):
+                wire_idx = next_wire_idx + i
+                wire_pos = int(box_left + cod_spacing * (i + 1))
+                new_wire_positions[wire_idx] = wire_pos
+                new_active_wires[wire_idx] = typ
+        
+        # Handle special cases for Cup and Swap
+        if isinstance(box, Cup):
+            # Cup consumes two wires, no outputs
+            pass
+        elif isinstance(box, Swap):
+            # Swap exchanges two wires
+            if len(input_indices) == 2:
+                idx1, idx2 = input_indices
+                pos1, pos2 = wire_positions[idx1], wire_positions[idx2]
+                # Add swapped wires to new positions
+                new_wire_positions[next_wire_idx] = pos2
+                new_wire_positions[next_wire_idx + 1] = pos1
+                new_active_wires[next_wire_idx] = active_wires[idx2]
+                new_active_wires[next_wire_idx + 1] = active_wires[idx1]
+        
+        # Draw output wires from box
+        if box.cod and not isinstance(box, (Cup, Swap)):
+            wire_line = ''
+            for idx in sorted(new_wire_positions.keys()):
+                if idx >= next_wire_idx:
+                    # This is a new output wire from the box
+                    pos = new_wire_positions[idx]
+                    wire_line = wire_line.ljust(pos) + self.chr_set['BAR']
+            if wire_line.strip():
+                lines.append(wire_line)
+        
+        # Update next wire index
+        if isinstance(box, Cup):
+            new_next_idx = next_wire_idx
+        elif isinstance(box, Swap):
+            new_next_idx = next_wire_idx + 2
+        else:
+            new_next_idx = next_wire_idx + len(box.cod)
+        
+        return lines, new_wire_positions, new_active_wires, new_next_idx
+    
+    def _get_box_text(self, box: Box) -> str:
+        """Get the text representation of a box."""
+        if isinstance(box, Word):
+            return box.name
+        elif isinstance(box, Cup):
+            # Use Unicode/ASCII cup representation
+            if self.chr_set == ASCII_CHAR_SET:
+                return '\\_/'
+            else:
+                return '╰─╯'
+        elif isinstance(box, Cap):
+            # Use Unicode/ASCII cap representation  
+            if self.chr_set == ASCII_CHAR_SET:
+                return '/‾\\'
+            else:
+                return '╭─╮'
+        elif isinstance(box, Swap):
+            # Use swap symbol
+            return 'X'
+        elif isinstance(box, Spider):
+            # Show spider with its dimensions
+            return f'Spider[{len(box.dom)}→{len(box.cod)}]'
+        elif isinstance(box, Daggered):
+            # Show daggered box
+            return f'{box.name}†'
+        elif isinstance(box, Frame):
+            # Show frame
+            return f'[{box.name}]'
+        else:
+            # Generic box: show name if available, otherwise show type transformation
+            if hasattr(box, 'name') and box.name:
+                return box.name
+            else:
+                # Show domain and codomain
+                dom_str = 'ε' if not box.dom else str(box.dom)
+                cod_str = 'ε' if not box.cod else str(box.cod)
+                return f'{dom_str}→{cod_str}'
 
 
 @dataclass

--- a/tests/backend/test_text_printer.py
+++ b/tests/backend/test_text_printer.py
@@ -135,15 +135,23 @@ def test_diagram_with_just_identities_2():
 
 
 def test_diagram_no_pregroup(diagram1):
-    with pytest.raises(NotImplementedError):
-        diagram1.normal_form().render_as_str()
+    # Now that we support non-pregroup diagrams, this should work
+    result = diagram1.normal_form().render_as_str()
+    assert isinstance(result, str)
+    # Check that some expected content is present
+    assert 'John' in result or 'gave' in result or 'Mary' in result
 
 
 def test_tensor():
-    with pytest.raises(NotImplementedError):
-        (Box("A", Dim(), Dim(3)) >> Box("A", Dim(3), Dim(4, 3))).render_as_str()
+    # Now that we support tensor diagrams, this should work
+    result = (Box("A", Dim(), Dim(3)) >> Box("A", Dim(3), Dim(4, 3))).render_as_str()
+    assert isinstance(result, str)
+    assert 'A' in result
 
 
 def test_quantum():
-    with pytest.raises(NotImplementedError):
-        (H @ qubit >> CX).render_as_str()
+    # Now that we support quantum diagrams, this should work
+    result = (H @ qubit >> CX).render_as_str()
+    assert isinstance(result, str)
+    assert 'H' in result
+    assert 'CX' in result

--- a/tests/backend/test_text_printer_general.py
+++ b/tests/backend/test_text_printer_general.py
@@ -1,0 +1,248 @@
+"""Tests for general text printing functionality for all diagram types."""
+
+import pytest
+
+from lambeq.backend.grammar import Box, Cap, Cup, Diagram, Id, Spider, Swap, Ty, Word, Daggered, Frame
+from lambeq.backend.quantum import CX, H, qubit, Ket
+from lambeq.backend.tensor import Box as TensorBox, Dim
+from lambeq.backend.drawing.text_printer import DiagramTextPrinter
+
+
+class TestGeneralTextPrinter:
+    """Test the general text printer for non-pregroup diagrams."""
+    
+    def test_empty_diagram(self):
+        """Test rendering an empty diagram."""
+        n = Ty('n')
+        diagram = Id(n)
+        printer = DiagramTextPrinter()
+        result = printer.diagram2str(diagram)
+        assert result == ""
+    
+    def test_simple_box_diagram(self):
+        """Test rendering a simple box diagram."""
+        n = Ty('n')
+        s = Ty('s')
+        f = Box('f', n, s)
+        diagram = Id(n) >> f
+        printer = DiagramTextPrinter()
+        result = printer.diagram2str(diagram)
+        assert 'f' in result
+        assert 'n' in result
+        assert 's' in result
+    
+    def test_composite_diagram(self):
+        """Test rendering a composite diagram."""
+        n = Ty('n')
+        s = Ty('s')
+        f = Box('f', n, s)
+        g = Box('g', s, n)
+        diagram = f >> g
+        printer = DiagramTextPrinter()
+        result = printer.diagram2str(diagram)
+        assert 'f' in result
+        assert 'g' in result
+    
+    def test_parallel_composition(self):
+        """Test rendering parallel composition."""
+        n = Ty('n')
+        s = Ty('s')
+        f = Box('f', n, s)
+        g = Box('g', n, s)
+        diagram = f @ g
+        printer = DiagramTextPrinter()
+        result = printer.diagram2str(diagram)
+        assert 'f' in result
+        assert 'g' in result
+    
+    def test_spider_rendering(self):
+        """Test rendering spider boxes."""
+        n = Ty('n')
+        diagram = Word("input", n) >> Spider(n, 1, 3)
+        printer = DiagramTextPrinter()
+        result = printer.diagram2str(diagram)
+        assert 'Spider[1→3]' in result
+    
+    def test_cap_rendering(self):
+        """Test rendering cap boxes."""
+        n = Ty('n')
+        diagram = Cap(n.r, n).to_diagram()
+        printer = DiagramTextPrinter()
+        result = printer.diagram2str(diagram)
+        # Check for cap symbol (unicode or ASCII)
+        assert '╭' in result or '/' in result
+    
+    def test_cup_rendering(self):
+        """Test rendering cup boxes in non-pregroup context."""
+        n = Ty('n')
+        diagram = Id(n) @ Id(n.r) >> Cup(n, n.r)
+        printer = DiagramTextPrinter()
+        result = printer.diagram2str(diagram)
+        # Check for cup symbol
+        assert '╰' in result or '\\' in result
+    
+    def test_swap_rendering(self):
+        """Test rendering swap boxes in non-pregroup context."""
+        n = Ty('n')
+        s = Ty('s')
+        diagram = Id(n) @ Id(s) >> Swap(n, s)
+        printer = DiagramTextPrinter()
+        result = printer.diagram2str(diagram)
+        assert 'X' in result
+    
+    def test_daggered_box(self):
+        """Test rendering daggered boxes."""
+        n = Ty('n')
+        s = Ty('s')
+        box = Box('f', n, s)
+        daggered = Daggered(box)
+        diagram = Id(s) >> daggered
+        printer = DiagramTextPrinter()
+        result = printer.diagram2str(diagram)
+        assert 'f†' in result
+    
+    def test_frame_box(self):
+        """Test rendering frame boxes."""
+        n = Ty('n')
+        s = Ty('s')
+        # Create a simple frame
+        inner = Box('inner', n, s)
+        frame = Frame('MyFrame', dom=n, cod=s, components=[inner])
+        diagram = Id(n) >> frame
+        printer = DiagramTextPrinter()
+        result = printer.diagram2str(diagram)
+        assert '[MyFrame]' in result
+    
+    def test_tensor_diagrams(self):
+        """Test rendering tensor diagrams."""
+        A = TensorBox("A", Dim(2), Dim(3))
+        B = TensorBox("B", Dim(3), Dim(4))
+        diagram = A >> B
+        printer = DiagramTextPrinter()
+        result = printer.diagram2str(diagram)
+        assert 'A' in result
+        assert 'B' in result
+        assert '2' in result
+        assert '4' in result
+    
+    def test_quantum_diagrams(self):
+        """Test rendering quantum diagrams."""
+        diagram = H @ qubit >> CX
+        printer = DiagramTextPrinter()
+        result = printer.diagram2str(diagram)
+        assert 'H' in result
+        assert 'CX' in result
+        assert 'qubit' in result
+    
+    def test_ascii_mode(self):
+        """Test ASCII-only rendering mode."""
+        n = Ty('n')
+        diagram = Cap(n.r, n).to_diagram()
+        
+        # Test Unicode mode
+        printer_unicode = DiagramTextPrinter(use_ascii=False)
+        result_unicode = printer_unicode.diagram2str(diagram)
+        assert '╭' in result_unicode or '╰' in result_unicode
+        
+        # Test ASCII mode
+        printer_ascii = DiagramTextPrinter(use_ascii=True)
+        result_ascii = printer_ascii.diagram2str(diagram)
+        assert '/' in result_ascii or '\\' in result_ascii
+        assert '╭' not in result_ascii and '╰' not in result_ascii
+    
+    def test_box_width_handling(self):
+        """Test that boxes are wide enough to fit their text."""
+        n = Ty('n')
+        s = Ty('s')
+        long_name = "VeryLongBoxNameThatShouldBeDisplayedProperly"
+        box = Box(long_name, n, s)
+        diagram = Id(n) >> box
+        printer = DiagramTextPrinter()
+        result = printer.diagram2str(diagram)
+        assert long_name in result
+    
+    def test_no_domain_box(self):
+        """Test rendering boxes with no domain."""
+        n = Ty('n')
+        box = Box('generator', Ty(), n)
+        diagram = box >> Id(n)
+        printer = DiagramTextPrinter()
+        result = printer.diagram2str(diagram)
+        assert 'generator' in result
+    
+    def test_no_codomain_box(self):
+        """Test rendering boxes with no codomain."""
+        n = Ty('n')
+        box = Box('sink', n, Ty())
+        diagram = Id(n) >> box
+        printer = DiagramTextPrinter()
+        result = printer.diagram2str(diagram)
+        assert 'sink' in result
+    
+    def test_complex_mixed_diagram(self):
+        """Test a complex diagram mixing different box types."""
+        n = Ty('n')
+        s = Ty('s')
+        
+        # Build a complex diagram
+        word1 = Word("start", n)
+        box1 = Box('process', n, n @ n)
+        box2 = Box('split', n @ n, n @ n @ n)
+        box3 = Box('merge', n @ n @ n, s)
+        
+        diagram = word1 >> box1 >> box2 >> box3
+        
+        printer = DiagramTextPrinter()
+        result = printer.diagram2str(diagram)
+        
+        # Check all components are present
+        assert 'start' in result
+        assert 'process' in result
+        assert 'split' in result
+        assert 'merge' in result
+    
+    def test_invalid_input(self):
+        """Test handling of invalid input."""
+        printer = DiagramTextPrinter()
+        with pytest.raises(ValueError):
+            printer.diagram2str("not a diagram")
+    
+    def test_word_spacing_option(self):
+        """Test the word_spacing option."""
+        n = Ty('n')
+        box1 = Box('A', n, n)
+        box2 = Box('B', n, n)
+        diagram = box1 @ box2
+        
+        # Test with different spacing
+        printer1 = DiagramTextPrinter(word_spacing=2)
+        result1 = printer1.diagram2str(diagram)
+        
+        printer2 = DiagramTextPrinter(word_spacing=5)
+        result2 = printer2.diagram2str(diagram)
+        
+        # The second result should have more spacing
+        assert len(result2) > len(result1)
+    
+    def test_at_separator_option(self):
+        """Test the use_at_separator option."""
+        n = Ty('n')
+        s = Ty('s')
+        box = Box('test', n @ s, n @ s)
+        diagram = Id(n @ s) >> box
+        
+        # Test with dot separator (default)
+        printer_dot = DiagramTextPrinter(use_at_separator=False)
+        result_dot = printer_dot.diagram2str(diagram)
+        assert '·' in result_dot or ' ' in result_dot  # Unicode dot or space
+        
+        # Test with @ separator
+        printer_at = DiagramTextPrinter(use_at_separator=True)
+        result_at = printer_at.diagram2str(diagram)
+        # Check that we use @ for type separation in the input line
+        lines = result_at.split('\n')
+        assert any('@' in line for line in lines)
+
+
+if __name__ == '__main__':
+    pytest.main([__file__])


### PR DESCRIPTION
## Summary of changes

- **General renderer**: Implemented `DiagramTextPrinter.diagram2str()` to handle arbitrary diagrams; still delegates to `PregroupTextPrinter` if `diagram.is_pregroup` for identical legacy output.
- **New internals**:
  - `_render_general_diagram(diagram)`: tracks wire columns, renders layers top-to-bottom.
  - `_render_layer(layer, ...)`: places a box and draws its input/output wires.
  - `_get_box_text(box)`: string representation for box types.
- **Box support**: `Word`, `Cup`, `Cap`, `Swap`, `Spider`, `Daggered`, `Frame`, and generic `Box` (name or dom→cod).
- **ASCII/Unicode**: Select via `use_ascii` (ASCII `|`, `_`, `\_/`, `/‾\`) vs Unicode (`│`, `─`, `╰─╯`, `╭─╮`). Type separator configurable via `use_at_separator`.
- **Width handling**: Boxes sized to fit their labels; simple spacing avoids overlap.
- **API update**: `drawing.render_as_str()` now supports non-pregroup diagrams (previously raised `NotImplementedError`).

## Scope

- Grammar, tensor, and quantum diagrams render in text mode.
- Pregroup rendering unchanged; prior expected strings in existing tests are preserved.

## Examples

Unicode (default):

```text
Hello  World
─────  ─────
  n    n.r·s
  ╰─────╯  │
```

ASCII (`use_ascii=True`):

```text
Hello  World
_____  _____
  n    n.r s
  \_____/  |
```

## Files changed

- `lambeq/backend/drawing/text_printer.py`: implemented general text rendering.
- `lambeq/backend/drawing/drawing.py`: `render_as_str()` now uses `DiagramTextPrinter` for all diagrams.
- `tests/backend/test_text_printer.py`: updated to expect success for non-pregroup/tensor/quantum.
- `tests/backend/test_text_printer_general.py`: new comprehensive tests for general rendering.
- `ASCII_DRAWING_IMPLEMENTATION.md`: short design/usage notes.

## Tests

- Added 20 tests for general rendering; updated existing tests to reflect new support for non-pregroup diagrams.
- All tests pass locally.

## Backwards compatibility

- Pregroup output unchanged.
- Behavior change: non-pregroup diagrams now render rather than raising `NotImplementedError`.

## Limitations / future work

- No foliation/box compaction; layout is simple and may differ from matplotlib/tikz backends.
- Basic spacing; complex diagrams may benefit from future layout refinements.

## Task list

- [x] Implement `DiagramTextPrinter.diagram2str()` for arbitrary diagrams
- [x] Update `drawing.render_as_str()` to call the general printer
- [x] Add comprehensive tests for grammar/tensor/quantum
- [x] Update existing tests to new behavior
- [x] Add brief implementation notes (`ASCII_DRAWING_IMPLEMENTATION.md`)
- [ ] Address reviewer feedback (as needed)
- [ ] Consider foliation/compression in a follow-up PR

## References

- Upstream issue: [CQCL/lambeq#140](https://github.com/CQCL/lambeq/issues/140)
