### PR TITLE
bugfix: PytorchTrainer memory leak

### DIFF
--- a/lambeq/training/nelder_mead_optimizer.py
+++ b/lambeq/training/nelder_mead_optimizer.py
@@ -259,7 +259,7 @@ class NelderMeadOptimizer(Optimizer):
                 raise ValueError(
                     'Objective function must return a scalar'
                 ) from e
-        return result   # type: ignore[return-value]
+        return result
 
     def backward(self, batch: tuple[Iterable[Any], np.ndarray]) -> float:
         """Calculate the gradients of the loss function.

--- a/lambeq/training/pytorch_trainer.py
+++ b/lambeq/training/pytorch_trainer.py
@@ -199,6 +199,6 @@ class PytorchTrainer(Trainer):
         self.optimizer.zero_grad()
         loss.backward()
         self.optimizer.step()
-        loss_item = loss.detach().item()
+        loss_item = loss.item()
         self.train_costs.append(loss_item)
         return y_hat.detach(), loss_item

--- a/lambeq/training/pytorch_trainer.py
+++ b/lambeq/training/pytorch_trainer.py
@@ -174,7 +174,7 @@ class PytorchTrainer(Trainer):
         with torch.no_grad():
             y_hat = self.model(x)
             loss = self.loss_function(y_hat, y.to(self.device))
-        return y_hat.detach(), loss.detach().item()
+        return y_hat.detach(), loss.item()
 
     def training_step(
             self,

--- a/lambeq/training/pytorch_trainer.py
+++ b/lambeq/training/pytorch_trainer.py
@@ -174,7 +174,7 @@ class PytorchTrainer(Trainer):
         with torch.no_grad():
             y_hat = self.model(x)
             loss = self.loss_function(y_hat, y.to(self.device))
-        return y_hat, loss.item()
+        return y_hat.detach(), loss.detach().item()
 
     def training_step(
             self,
@@ -196,8 +196,9 @@ class PytorchTrainer(Trainer):
         x, y = batch
         y_hat = self.model(x)
         loss = self.loss_function(y_hat, y.to(self.device))
-        self.train_costs.append(loss.item())
         self.optimizer.zero_grad()
         loss.backward()
         self.optimizer.step()
-        return y_hat, loss.item()
+        loss_item = loss.detach().item()
+        self.train_costs.append(loss_item)
+        return y_hat.detach(), loss_item


### PR DESCRIPTION
Detach the tensors returned in the training loops to ensure the computation graph can be cleared from memory properly after each batch.